### PR TITLE
feat: unconfirmed npc_inrange command

### DIFF
--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -610,7 +610,7 @@ export default class Npc extends PathingEntity {
         return this.target.isValid();
     }
 
-    private targetWithinMaxRange(): boolean {
+    public targetWithinMaxRange(): boolean {
         if (!this.target) {
             return true;
         }

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -255,6 +255,7 @@ export const enum ScriptOpcode {
     NPC_ATTACKRANGE, // official
     NPC_HASOP, // official
     NPC_ARRIVEDELAY,
+    NPC_INRANGE,
 
     // Loc ops (3000-3499)
     LOC_ADD = 3000, // official
@@ -698,6 +699,7 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['NPC_ATTACKRANGE', ScriptOpcode.NPC_ATTACKRANGE],
     ['NPC_HASOP', ScriptOpcode.NPC_HASOP],
     ['NPC_ARRIVEDELAY', ScriptOpcode.NPC_ARRIVEDELAY],
+    ['NPC_INRANGE', ScriptOpcode.NPC_INRANGE],
     ['LOC_ADD', ScriptOpcode.LOC_ADD],
     ['LOC_ANGLE', ScriptOpcode.LOC_ANGLE],
     ['LOC_ANIM', ScriptOpcode.LOC_ANIM],

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -704,6 +704,10 @@ const ScriptOpcodePointers: {
         corrupt: ['p_active_player', 'p_active_player2', ...POINTER_GROUP_FIND, 'last_com', 'last_int', 'last_item', 'last_slot', 'last_targetslot', 'last_useitem', 'last_useslot'],
         require2: ['active_npc2']
     },
+    [ScriptOpcode.NPC_INRANGE]: {
+        require: ['active_npc'],
+        require2: ['active_npc2']
+    },
 
     // Loc ops
     [ScriptOpcode.LOC_ADD]: {

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -501,6 +501,9 @@ const NpcOps: CommandHandlers = {
         }
 
         state.execution = ScriptState.NPC_SUSPENDED;
+    }),
+    [ScriptOpcode.NPC_INRANGE]: checkedHandler(ActiveNpc, state => {
+        state.pushInt(state.activeNpc.targetWithinMaxRange() ? 1 : 0);
     })
 };
 


### PR DESCRIPTION
Not sure if this is how jagex does it. It's sort of scuffed since it varies depending on the npc's current mode...

This implementation would need you to set the mode before calling npc_inrange. 
```java
npc_setmode(applayer2);
if (npc_inrange() = false) {
    npc_setmode(playerescape);
}
```

Video of this command used for npc retaliation:


https://github.com/user-attachments/assets/52263083-abe8-4f31-a927-87a7232103c0

