### PR TITLE
fix: big npcs were pathing diagonally if both cardinal directions were blocked

### DIFF
--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -499,6 +499,7 @@ export default abstract class PathingEntity extends Entity {
                         this.queueWaypoint(this.x, CoordGrid.moveZ(this.z, dir));
                         return;
                     }
+                    return;
                 }
                 this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, extraFlag, collisionStrategy));
             } else {


### PR DESCRIPTION
Missing return causes:
```ts
this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, extraFlag, collisionStrategy));
```
to run, allowing big npc's to diagonally path.

This doesnt match this 2006 [video](https://youtu.be/7t2TE6TjD7s?t=106)!

https://github.com/user-attachments/assets/dca9de4d-21d9-4e42-9138-92c051d2039b

Before:

https://github.com/user-attachments/assets/1c2b5b3a-d3eb-476c-9278-32240797f4d4


After:

https://github.com/user-attachments/assets/ce6ea5db-c4f9-41c1-aacd-e6de95c1bebc

