### PR TITLE
feat: inv_dropitem_delayed command

### DIFF
--- a/src/engine/entity/ObjDelayedRequest.ts
+++ b/src/engine/entity/ObjDelayedRequest.ts
@@ -1,0 +1,21 @@
+import Obj from '#/engine/entity/Obj.js';
+import Linkable from '#/util/Linkable.js';
+
+export class ObjDelayedRequest extends Linkable {
+    // Obj to add
+    obj: Obj;
+    // Player who dropped
+    receiver64: bigint;
+    // Duration for obj to last after its added
+    duration: number;
+    // Duration for obj to wait to be added
+    delay: number;
+
+    constructor(obj: Obj, duration: number, delay: number, receiver64: bigint = Obj.NO_RECEIVER) {
+        super();
+        this.obj = obj;
+        this.receiver64 = receiver64;
+        this.duration = duration;
+        this.delay = delay;
+    }
+}

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -334,6 +334,7 @@ export const enum ScriptOpcode {
     INV_DEL, // official
     INV_DELSLOT,
     INV_DROPITEM,
+    INV_DROPITEM_DELAYED,
     INV_DROPSLOT,
     INV_FREESPACE,
     INV_GETNUM,
@@ -766,6 +767,7 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['INV_DEL', ScriptOpcode.INV_DEL],
     ['INV_DELSLOT', ScriptOpcode.INV_DELSLOT],
     ['INV_DROPITEM', ScriptOpcode.INV_DROPITEM],
+    ['INV_DROPITEM_DELAYED', ScriptOpcode.INV_DROPITEM_DELAYED],
     ['INV_DROPSLOT', ScriptOpcode.INV_DROPSLOT],
     ['INV_FREESPACE', ScriptOpcode.INV_FREESPACE],
     ['INV_GETNUM', ScriptOpcode.INV_GETNUM],

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -853,6 +853,12 @@ const ScriptOpcodePointers: {
         require2: ['active_player2'],
         set2: ['active_obj2']
     },
+    [ScriptOpcode.INV_DROPITEM_DELAYED]: {
+        require: ['active_player'],
+        set: ['active_obj'],
+        require2: ['active_player2'],
+        set2: ['active_obj2']
+    },
     [ScriptOpcode.INV_DROPSLOT]: {
         require: ['active_player'],
         set: ['active_obj'],


### PR DESCRIPTION
Ash has said in the past that a command like obj_adddelayed, is a more recent command. They currently use it for firemaking.

I think something like inv_dropitem_delayed has to have existed in 2004 though. In old videos, the arrows will land where the target *used* to be... This means that they wouldve needed to store the coord some how (with no local vars!). `obj_add` also takes namedobj, so they would've needed to have a way to change the ammo obj to namedobj (confident they did not do this).

The big nail in the coffin is when I was implementing magic shortbow spec. Theres a p_delay(0) in between the two arrows... since our current arrow dropping relies on world_delay, there will be certain scenarios where you want to obj_add instantly after the p_delay. With two arrows dropping at potentially different times, this can get messy real quick.


