### PR TITLE
feat: enforce friends/ignore list limits from packet handler

### DIFF
--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -222,7 +222,11 @@ export class FriendServerRepository {
             return;
         }
 
-        // TODO check player is not over friends limit
+        const list = await db.selectFrom('friendlist').where('account_id', '=', accountId.id).select(({ fn }) => fn.countAll().as('count')).executeTakeFirst();
+
+        if (list && list.count as number >= 100) {
+            return;
+        }
 
         await db
             .insertInto('friendlist')
@@ -252,7 +256,11 @@ export class FriendServerRepository {
 
         const { id } = account;
 
-        // TODO check player is not over ignore limit
+        const list = await db.selectFrom('ignorelist').where('account_id', '=', id).select(({ fn }) => fn.countAll().as('count')).executeTakeFirst();
+
+        if (list && list.count as number >= 100) {
+            return;
+        }
 
         let query = db.insertInto('ignorelist').values({
             account_id: id,

--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -210,8 +210,6 @@ export class FriendServerRepository {
             return;
         }
 
-        this.playerFriends[username].push(targetUsername37);
-
         // I tried to do all this in 1 query but Kyesly wasn't happy
         const accountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
 
@@ -227,6 +225,8 @@ export class FriendServerRepository {
         if (list && list.count as number >= 100) {
             return;
         }
+
+        this.playerFriends[username].push(targetUsername37);
 
         await db
             .insertInto('friendlist')
@@ -246,8 +246,6 @@ export class FriendServerRepository {
             return;
         }
 
-        this.playerIgnores[username].push(value37);
-
         const account = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
 
         if (!account) {
@@ -261,6 +259,8 @@ export class FriendServerRepository {
         if (list && list.count as number >= 100) {
             return;
         }
+
+        this.playerIgnores[username].push(value37);
 
         let query = db.insertInto('ignorelist').values({
             account_id: id,


### PR DESCRIPTION
Logic is handled client-side but should still be limited server-side. All players can have 100 friends, and 100 entries on their ignore list.