### PR TITLE
feat: enforce friends/ignore list limits from packet handler

### DIFF
--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -210,8 +210,6 @@ export class FriendServerRepository {
             return;
         }
 
-        this.playerFriends[username].push(targetUsername37);
-
         // I tried to do all this in 1 query but Kyesly wasn't happy
         const account = await db.selectFrom('account').select([ 'id', 'members' ]).where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
 
@@ -229,6 +227,8 @@ export class FriendServerRepository {
         if (list && list.count as number >= limit) {
             return;
         }
+
+        this.playerFriends[username].push(targetUsername37);
 
         await db
             .insertInto('friendlist')

--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -248,8 +248,6 @@ export class FriendServerRepository {
             return;
         }
 
-        this.playerIgnores[username].push(value37);
-
         const account = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
 
         if (!account) {
@@ -263,6 +261,8 @@ export class FriendServerRepository {
         if (list && list.count as number >= 100) {
             return;
         }
+
+        this.playerIgnores[username].push(value37);
 
         let query = db.insertInto('ignorelist').values({
             account_id: id,

--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -213,21 +213,27 @@ export class FriendServerRepository {
         this.playerFriends[username].push(targetUsername37);
 
         // I tried to do all this in 1 query but Kyesly wasn't happy
-        const accountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
+        const account = await db.selectFrom('account').select([ 'id', 'members' ]).where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
 
         const friendAccountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(targetUsername37)).limit(1).executeTakeFirst();
 
-        if (!accountId || !friendAccountId) {
+        if (!account || !friendAccountId) {
             // console.error(`[Friends]: ${username} tried to add ${targetUsername} to their friend list, but one of the accounts does not exist`);
             return;
         }
 
-        // TODO check player is not over friends limit
+        const list = await db.selectFrom('friendlist').where('account_id', '=', account.id).select(({ fn }) => fn.countAll().as('count')).executeTakeFirst();
+
+        const limit = account.members ? 200 : 100;
+
+        if (list && list.count as number >= limit) {
+            return;
+        }
 
         await db
             .insertInto('friendlist')
             .values({
-                account_id: accountId.id,
+                account_id: account.id,
                 friend_account_id: friendAccountId.id
             })
             .execute();
@@ -252,7 +258,11 @@ export class FriendServerRepository {
 
         const { id } = account;
 
-        // TODO check player is not over ignore limit
+        const list = await db.selectFrom('ignorelist').where('account_id', '=', id).select(({ fn }) => fn.countAll().as('count')).executeTakeFirst();
+
+        if (list && list.count as number >= 100) {
+            return;
+        }
 
         let query = db.insertInto('ignorelist').values({
             account_id: id,


### PR DESCRIPTION
Logic is handled client-side but should still be limited server-side. Members can have 200 friends, f2p can have 100, both can have 100 entries on their ignore list.