### PR TITLE
feat: support running multiple profiles

### DIFF
--- a/prisma/multiworld/migrations/20250703052910_profile_logins/migration.sql
+++ b/prisma/multiworld/migrations/20250703052910_profile_logins/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `logged_in` on the `account` table. All the data in the column will be lost.
+  - You are about to drop the column `logged_out` on the `account` table. All the data in the column will be lost.
+  - You are about to drop the column `login_time` on the `account` table. All the data in the column will be lost.
+  - You are about to drop the column `logout_time` on the `account` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `account` DROP COLUMN `logged_in`,
+    DROP COLUMN `logged_out`,
+    DROP COLUMN `login_time`,
+    DROP COLUMN `logout_time`;
+
+-- CreateTable
+CREATE TABLE `account_login` (
+    `account_id` INTEGER NOT NULL,
+    `profile` VARCHAR(191) NOT NULL,
+    `logged_in` INTEGER NOT NULL DEFAULT 0,
+    `login_time` DATETIME(3) NULL,
+    `logged_out` INTEGER NOT NULL DEFAULT 0,
+    `logout_time` DATETIME(3) NULL,
+
+    UNIQUE INDEX `account_login_account_id_profile_key`(`account_id`, `profile`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/multiworld/migrations/20250705031142_profile_friends/migration.sql
+++ b/prisma/multiworld/migrations/20250705031142_profile_friends/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The primary key for the `friendlist` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `ignorelist` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE `friendlist` DROP PRIMARY KEY,
+    ADD COLUMN `profile` VARCHAR(191) NOT NULL DEFAULT 'main',
+    ADD PRIMARY KEY (`account_id`, `profile`, `friend_account_id`);
+
+-- AlterTable
+ALTER TABLE `ignorelist` DROP PRIMARY KEY,
+    ADD COLUMN `profile` VARCHAR(191) NOT NULL DEFAULT 'main',
+    ADD PRIMARY KEY (`account_id`, `profile`, `value`);

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -25,14 +25,6 @@ model account {
     registration_ip   String?
     registration_date DateTime @default(now())
 
-    // current login
-    logged_in  Int       @default(0)
-    login_time DateTime?
-
-    // last logout
-    logged_out  Int       @default(0)
-    logout_time DateTime?
-
     muted_until  DateTime?
     banned_until DateTime?
 
@@ -51,6 +43,22 @@ model account {
     tfa_secret_base32 String?
     // How many incorrect attempts have been made in a row
     tfa_incorrect_attempts Int @default(0)
+}
+
+// account logged in status
+model account_login {
+    account_id Int
+    profile String
+
+    // current login
+    logged_in  Int       @default(0)
+    login_time DateTime?
+
+    // last logout
+    logged_out  Int       @default(0)
+    logout_time DateTime?
+
+    @@unique([account_id, profile])
 }
 
 model session {

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -180,19 +180,21 @@ model hiscore_large {
 
 model friendlist {
     account_id        Int
+    profile           String @default("main")
     friend_account_id Int
 
     created DateTime @default(now())
 
-    @@id([account_id, friend_account_id])
+    @@id([account_id, profile, friend_account_id])
 }
 
 model ignorelist {
     account_id Int
+    profile    String   @default("main")
     value      String
     created    DateTime @default(now())
 
-    @@id([account_id, value])
+    @@id([account_id, profile, value])
 }
 
 model public_chat {

--- a/prisma/singleworld/migrations/20250703052930_profile_logins/migration.sql
+++ b/prisma/singleworld/migrations/20250703052930_profile_logins/migration.sql
@@ -1,0 +1,52 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `logged_in` on the `account` table. All the data in the column will be lost.
+  - You are about to drop the column `logged_out` on the `account` table. All the data in the column will be lost.
+  - You are about to drop the column `login_time` on the `account` table. All the data in the column will be lost.
+  - You are about to drop the column `logout_time` on the `account` table. All the data in the column will be lost.
+
+*/
+-- CreateTable
+CREATE TABLE "account_login" (
+    "account_id" INTEGER NOT NULL,
+    "profile" TEXT NOT NULL,
+    "logged_in" INTEGER NOT NULL DEFAULT 0,
+    "login_time" DATETIME,
+    "logged_out" INTEGER NOT NULL DEFAULT 0,
+    "logout_time" DATETIME
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_account" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "password_updated" DATETIME,
+    "email" TEXT,
+    "oauth_provider" TEXT,
+    "registration_ip" TEXT,
+    "registration_date" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "muted_until" DATETIME,
+    "banned_until" DATETIME,
+    "tracked_until" DATETIME,
+    "staffmodlevel" INTEGER NOT NULL DEFAULT 0,
+    "notes" TEXT,
+    "notes_updated" DATETIME,
+    "members" BOOLEAN NOT NULL DEFAULT false,
+    "tfa_enabled" BOOLEAN NOT NULL DEFAULT false,
+    "tfa_last_code" INTEGER NOT NULL DEFAULT 0,
+    "tfa_secret_base32" TEXT,
+    "tfa_incorrect_attempts" INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO "new_account" ("banned_until", "email", "id", "members", "muted_until", "notes", "notes_updated", "oauth_provider", "password", "password_updated", "registration_date", "registration_ip", "staffmodlevel", "tfa_enabled", "tfa_incorrect_attempts", "tfa_last_code", "tfa_secret_base32", "username") SELECT "banned_until", "email", "id", "members", "muted_until", "notes", "notes_updated", "oauth_provider", "password", "password_updated", "registration_date", "registration_ip", "staffmodlevel", "tfa_enabled", "tfa_incorrect_attempts", "tfa_last_code", "tfa_secret_base32", "username" FROM "account";
+DROP TABLE "account";
+ALTER TABLE "new_account" RENAME TO "account";
+CREATE UNIQUE INDEX "account_username_key" ON "account"("username");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "account_login_account_id_profile_key" ON "account_login"("account_id", "profile");

--- a/prisma/singleworld/migrations/20250705031333_profile_friends/migration.sql
+++ b/prisma/singleworld/migrations/20250705031333_profile_friends/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - The primary key for the `friendlist` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `ignorelist` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_friendlist" (
+    "account_id" INTEGER NOT NULL,
+    "profile" TEXT NOT NULL DEFAULT 'main',
+    "friend_account_id" INTEGER NOT NULL,
+    "created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("account_id", "profile", "friend_account_id")
+);
+INSERT INTO "new_friendlist" ("account_id", "created", "friend_account_id") SELECT "account_id", "created", "friend_account_id" FROM "friendlist";
+DROP TABLE "friendlist";
+ALTER TABLE "new_friendlist" RENAME TO "friendlist";
+CREATE TABLE "new_ignorelist" (
+    "account_id" INTEGER NOT NULL,
+    "profile" TEXT NOT NULL DEFAULT 'main',
+    "value" TEXT NOT NULL,
+    "created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("account_id", "profile", "value")
+);
+INSERT INTO "new_ignorelist" ("account_id", "created", "value") SELECT "account_id", "created", "value" FROM "ignorelist";
+DROP TABLE "ignorelist";
+ALTER TABLE "new_ignorelist" RENAME TO "ignorelist";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -25,14 +25,6 @@ model account {
     registration_ip   String?
     registration_date DateTime @default(now())
 
-    // current login
-    logged_in  Int       @default(0)
-    login_time DateTime?
-
-    // last logout
-    logged_out  Int       @default(0)
-    logout_time DateTime?
-
     muted_until  DateTime?
     banned_until DateTime?
 
@@ -51,6 +43,22 @@ model account {
     tfa_secret_base32 String?
     // How many incorrect attempts have been made in a row
     tfa_incorrect_attempts Int @default(0)
+}
+
+// account logged in status
+model account_login {
+    account_id Int
+    profile String
+
+    // current login
+    logged_in  Int       @default(0)
+    login_time DateTime?
+
+    // last logout
+    logged_out  Int       @default(0)
+    logout_time DateTime?
+
+    @@unique([account_id, profile])
 }
 
 // logged in sessions

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -181,19 +181,21 @@ model hiscore_large {
 
 model friendlist {
     account_id        Int
+    profile           String    @default("main")
     friend_account_id Int
 
     created           DateTime  @default(now())
 
-    @@id([account_id, friend_account_id])
+    @@id([account_id, profile, friend_account_id])
 }
 
 model ignorelist {
     account_id        Int
+    profile           String    @default("main")
     value             String
     created           DateTime  @default(now())
 
-    @@id([account_id, value])
+    @@id([account_id, profile, value])
 }
 
 model public_chat {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -49,6 +49,7 @@ export type account_tag = {
 };
 export type friendlist = {
     account_id: number;
+    profile: Generated<string>;
     friend_account_id: number;
     created: Generated<string>;
 };
@@ -70,6 +71,7 @@ export type hiscore_large = {
 };
 export type ignorelist = {
     account_id: number;
+    profile: Generated<string>;
     value: string;
     created: Generated<string>;
 };

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -13,10 +13,6 @@ export type account = {
     oauth_provider: string | null;
     registration_ip: string | null;
     registration_date: Generated<string>;
-    logged_in: Generated<number>;
-    login_time: string | null;
-    logged_out: Generated<number>;
-    logout_time: string | null;
     muted_until: string | null;
     banned_until: string | null;
     staffmodlevel: Generated<number>;
@@ -27,6 +23,14 @@ export type account = {
     tfa_last_code: Generated<number>;
     tfa_secret_base32: string | null;
     tfa_incorrect_attempts: Generated<number>;
+};
+export type account_login = {
+    account_id: number;
+    profile: string;
+    logged_in: Generated<number>;
+    login_time: string | null;
+    logged_out: Generated<number>;
+    logout_time: string | null;
 };
 export type account_session = {
     id: Generated<number>;
@@ -208,6 +212,7 @@ export type wealth_event = {
 };
 export type DB = {
     account: account;
+    account_login: account_login;
     account_session: account_session;
     account_tag: account_tag;
     friendlist: friendlist;

--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -298,10 +298,13 @@ export class FriendServerRepository {
         this.playerIgnores[username].splice(index, 1);
 
         await db.deleteFrom('ignorelist')
-            .innerJoin('account', 'account.id', 'ignorelist.account_id')
-            .where('ignorelist.profile', '=', this.profile)
-            .where('account.username', '=', fromBase37(username37))
+            .where('profile', '=', this.profile)
             .where('value', '=', fromBase37(value37))
+            .where('account_id', 'in',
+                db.selectFrom('account')
+                    .select('id')
+                    .where('username', '=', username)
+            )
             .execute();
     }
 

--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -10,6 +10,7 @@ import { fromBase37, toBase37 } from '#/util/JString.js';
  * Responsible for database queries and caching.
  */
 export class FriendServerRepository {
+    private readonly profile: string;
     /**
      * playersByWorld[worldId][playerIndex] = username37 | null
      */
@@ -39,6 +40,10 @@ export class FriendServerRepository {
      * playerIgnores[username] = username37[]
      */
     private playerIgnores: Record<string, bigint[]> = {};
+
+    constructor(profile: string) {
+        this.profile = profile;
+    }
 
     public initializeWorld(world: number, size: number) {
         if (this.playersByWorld[world]) {
@@ -177,7 +182,7 @@ export class FriendServerRepository {
 
     public async deleteFriend(username37: bigint, targetUsername37: bigint) {
         const username = fromBase37(username37);
-        const _targetUsername = fromBase37(targetUsername37);
+        const targetUsername = fromBase37(targetUsername37);
 
         this.playerFriends[username] = this.playerFriends[username] ?? [];
         const index = this.playerFriends[username].indexOf(targetUsername37);
@@ -189,19 +194,22 @@ export class FriendServerRepository {
 
         this.playerFriends[username].splice(index, 1);
 
-        // I tried to do all this in 1 query but Kysely wasn't happy
-        const accountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
-
-        const friendAccountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(targetUsername37)).limit(1).executeTakeFirst();
-
-        if (accountId && friendAccountId) {
-            await db.deleteFrom('friendlist').where('account_id', '=', accountId.id).where('friend_account_id', '=', friendAccountId.id).execute();
-        }
+        await db.deleteFrom('friendlist')
+            .where('profile', '=', this.profile)
+            .where('account_id', 'in', 
+                db.selectFrom('account')
+                    .select('id')
+                    .where('username', '=', username))
+            .where('friend_account_id', 'in', 
+                db.selectFrom('account')
+                    .select('id')
+                    .where('username', '=', targetUsername))
+            .execute();
     }
 
     public async addFriend(username37: bigint, targetUsername37: bigint) {
         const username = fromBase37(username37);
-        const _targetUsername = fromBase37(targetUsername37);
+        const targetUsername = fromBase37(targetUsername37);
 
         this.playerFriends[username] = this.playerFriends[username] ?? [];
 
@@ -213,9 +221,9 @@ export class FriendServerRepository {
         this.playerFriends[username].push(targetUsername37);
 
         // I tried to do all this in 1 query but Kyesly wasn't happy
-        const accountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
+        const accountId = await db.selectFrom('account').select('id').where('username', '=', username).limit(1).executeTakeFirst();
 
-        const friendAccountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(targetUsername37)).limit(1).executeTakeFirst();
+        const friendAccountId = await db.selectFrom('account').select('id').where('username', '=', targetUsername).limit(1).executeTakeFirst();
 
         if (!accountId || !friendAccountId) {
             // console.error(`[Friends]: ${username} tried to add ${targetUsername} to their friend list, but one of the accounts does not exist`);
@@ -228,6 +236,7 @@ export class FriendServerRepository {
             .insertInto('friendlist')
             .values({
                 account_id: accountId.id,
+                profile: this.profile,
                 friend_account_id: friendAccountId.id
             })
             .execute();
@@ -256,6 +265,7 @@ export class FriendServerRepository {
 
         let query = db.insertInto('ignorelist').values({
             account_id: id,
+            profile: this.profile,
             value: fromBase37(value37)
         });
 
@@ -287,14 +297,12 @@ export class FriendServerRepository {
 
         this.playerIgnores[username].splice(index, 1);
 
-        const accountId = await db.selectFrom('account').select('id').where('username', '=', fromBase37(username37)).limit(1).executeTakeFirst();
-
-        if (!accountId) {
-            console.error(`[Friends]: No account found for ${username}`);
-            return;
-        }
-
-        await db.deleteFrom('ignorelist').where('account_id', '=', accountId.id).where('value', '=', fromBase37(value37)).execute();
+        await db.deleteFrom('ignorelist')
+            .innerJoin('account', 'account.id', 'ignorelist.account_id')
+            .where('ignorelist.profile', '=', this.profile)
+            .where('account.username', '=', fromBase37(username37))
+            .where('value', '=', fromBase37(value37))
+            .execute();
     }
 
     public setChatMode(username37: bigint, privateChat: ChatModePrivate) {
@@ -343,6 +351,7 @@ export class FriendServerRepository {
             .innerJoin('account as local', 'local.id', 'f.account_id')
             .select('a.username')
             .where('local.username', '=', username)
+            .where('f.profile', '=', this.profile)
             .orderBy('f.created asc')
             .execute();
         const friendUsername37s = friendUsernames.map(f => toBase37(f.username));
@@ -352,7 +361,13 @@ export class FriendServerRepository {
 
     private async loadIgnores(username37: bigint) {
         const username = fromBase37(username37);
-        const ignores = await db.selectFrom('account as local').innerJoin('ignorelist as i', 'local.id', 'i.account_id').select('i.value').where('local.username', '=', username).orderBy('i.created asc').execute();
+        const ignores = await db.selectFrom('account as local')
+            .innerJoin('ignorelist as i', 'local.id', 'i.account_id')
+            .select('i.value')
+            .where('local.username', '=', username)
+            .where('i.profile', '=', this.profile)
+            .orderBy('i.created asc')
+            .execute();
 
         const ignoreUsername37s = ignores.map(f => toBase37(f.value));
 

--- a/src/server/login/LoginServer.ts
+++ b/src/server/login/LoginServer.ts
@@ -16,8 +16,9 @@ import { printInfo } from '#/util/Logger.js';
 import { getUnreadMessageCount } from '#/util/Messages.js';
 import { startManagementWeb } from '#/web.js';
 
-async function updateHiscores(username: string, player: Player, profile: string) {
-    const account = await db.selectFrom('account').where('username', '=', username).selectAll().executeTakeFirstOrThrow();
+async function updateHiscores(account: { id: number, staffmodlevel: number } | undefined, player: Player, profile: string) {
+    if (!account)
+        return;
 
     if (account.staffmodlevel > 1) {
         return;
@@ -150,12 +151,13 @@ export default class LoginServer {
 
                     if (type === 'world_startup') {
                         await db
-                            .updateTable('account')
+                            .updateTable('account_login')
                             .set({
                                 logged_in: 0,
                                 login_time: null
                             })
                             .where('logged_in', '=', nodeId)
+                            .where('profile', '=', profile)
                             .execute();
                     } else if (type === 'player_login') {
                         const { replyTo, username, password, uid, socket, remoteAddress, reconnecting, hasSave } = msg;
@@ -185,7 +187,14 @@ export default class LoginServer {
                                 return;
                             }
 
-                            const account = await db.selectFrom('account').where('username', '=', username).selectAll().executeTakeFirst();
+                            const account = await db.selectFrom('account')
+                                .leftJoin('account_login', join => join
+                                    .onRef('account_id', '=', 'id')
+                                    .on('profile', '=', profile)
+                                )
+                                .where('username', '=', username)
+                                .selectAll()
+                                .executeTakeFirst();
 
                             if (!Environment.WEBSITE_REGISTRATION && !account) {
                                 // register the user automatically
@@ -333,7 +342,7 @@ export default class LoginServer {
                                     );
                                 }
                                 return;
-                            } else if (account.logged_in !== 0) {
+                            } else if (account.logged_in !== null && account.logged_in !== 0) {
                                 // already logged in elsewhere
                                 s.send(
                                     JSON.stringify({
@@ -342,7 +351,12 @@ export default class LoginServer {
                                     })
                                 );
                                 return;
-                            } else if (account.staffmodlevel < 2 && account.logged_out !== 0 && account.logged_out !== nodeId && account.logout_time !== null && new Date(account.logout_time) >= new Date(Date.now() - 45000)) {
+                            } else if (account.staffmodlevel < 2 
+                                && account.logged_out !== null 
+                                && account.logged_out !== 0 
+                                && account.logged_out !== nodeId 
+                                && account.logout_time !== null 
+                                && new Date(account.logout_time) >= new Date(Date.now() - 45000)) {
                                 // rate limited (hop timer)
                                 s.send(
                                     JSON.stringify({
@@ -410,14 +424,26 @@ export default class LoginServer {
                             }
 
                             // Login is valid - update account table
-                            await db
-                                .updateTable('account')
-                                .set({
-                                    logged_in: nodeId,
-                                    login_time: toDbDate(new Date())
-                                })
-                                .where('id', '=', account.id)
-                                .executeTakeFirst();
+                            if (account.account_id) {
+                                await db.updateTable('account_login')
+                                    .set({
+                                        logged_in: nodeId,
+                                        login_time: toDbDate(new Date())
+                                    })
+                                    .where('account_id', '=', account.id)
+                                    .where('profile', '=', profile)
+                                    .executeTakeFirst();
+                            }
+                            else {
+                                await db.insertInto('account_login')
+                                    .values({
+                                        account_id: account.id,
+                                        profile: profile,
+                                        logged_in: nodeId,
+                                        login_time: toDbDate(new Date())
+                                    })
+                                    .executeTakeFirst();
+                            }
                         } finally {
                             this.loginRequests.delete(safeName);
                         }
@@ -435,16 +461,28 @@ export default class LoginServer {
                             console.error(username, 'Invalid save file');
                         }
 
-                        await db
-                            .updateTable('account')
-                            .set({
-                                logged_in: 0,
-                                login_time: null,
-                                logged_out: nodeId,
-                                logout_time: toDbDate(new Date())
-                            })
+                        const account = await db.selectFrom('account')
+                            .leftJoin('account_login', join => join
+                                .onRef('account_id', '=', 'id')
+                                .on('profile', '=', profile)
+                            )
                             .where('username', '=', username)
+                            .selectAll()
                             .executeTakeFirst();
+                        
+                        if (account?.account_id) {
+                            await db
+                                .updateTable('account_login')
+                                .set({
+                                    logged_in: 0,
+                                    login_time: null,
+                                    logged_out: nodeId,
+                                    logout_time: toDbDate(new Date())
+                                })
+                                .where('account_id', '=', account.id)
+                                .where('profile', '=', profile)
+                                .executeTakeFirst();
+                        }
 
                         s.send(
                             JSON.stringify({
@@ -453,7 +491,7 @@ export default class LoginServer {
                             })
                         );
 
-                        await updateHiscores(username, PlayerLoading.load(username, new Packet(raw), null), profile);
+                        await updateHiscores(account, PlayerLoading.load(username, new Packet(raw), null), profile);
                     } else if (type === 'player_autosave') {
                         const { username, save } = msg;
 
@@ -470,14 +508,28 @@ export default class LoginServer {
                     } else if (type === 'player_force_logout') {
                         const { username } = msg;
 
-                        await db
-                            .updateTable('account')
-                            .set({
-                                logged_in: 0,
-                                login_time: null
-                            })
+                        const account = await db
+                            .selectFrom('account')
+                            .leftJoin('account_login', join => join
+                                .onRef('account_id', '=', 'id')
+                                .on('profile', '=', profile)
+                            )
                             .where('username', '=', username)
+                            .selectAll()
                             .executeTakeFirst();
+
+                        if (account?.account_id) {
+                            await db
+                                .updateTable('account_login')
+                                .set({
+                                    logged_in: 0,
+                                    login_time: null
+                                })
+                                .where('account_id', '=', account.id)
+                                .where('profile', '=', profile)
+                                .executeTakeFirst();
+                        }
+                        
                     } else if (type === 'player_ban') {
                         const { _staff, username, until } = msg;
 


### PR DESCRIPTION
These changes allow the same account to login simultaneously to multiple profiles. Private messages are now limited to the same profile type.

Database changes:
- Updated `account` schema to move login/logout status to profile based `account_login`.
- Updated `friendlist` and `ignorelist` schemas to be profile specific.

Consideration: `friendlist` and `ignorelist` tables will have default value inserted for `profile` on existing entries. If running server with non-default profile, lists will be effectively cleared unless manually corrected.