### PR TITLE
fix(engine): fix midi lookup for songs with multiple underscores

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1848,7 +1848,7 @@ export default class Player extends PathingEntity {
 
     // todo: make compiler do this at pack time
     playSong(name: string) {
-        const id = MidiPack.getByName(name.toLowerCase().replace(' ', '_'));
+        const id = MidiPack.getByName(name.toLowerCase().replaceAll(' ', '_'));
         if (id !== -1) {
             this.write(new MidiSong(id));
         }


### PR DESCRIPTION
Existing code would fail to play i.e. "Army of darkness" because `replace` only replaced the first '` `' with '`_`', meaning it would try to locate "army_of darkness" from the pack.

Tested on Java and Webclient.

The `225` revision does not have this bug.