### PR TITLE
fix: make all big npc movement path non-diagonally

### DIFF
--- a/src/engine/GameMap.ts
+++ b/src/engine/GameMap.ts
@@ -386,6 +386,9 @@ export function reachedObj(level: number, srcX: number, srcZ: number, destX: num
 }
 
 export function canTravel(level: number, x: number, z: number, offsetX: number, offsetZ: number, size: number, extraFlag: number, collision: CollisionType): boolean {
+    if (!Environment.NODE_MEMBERS && !World.gameMap.isFreeToPlay(x + offsetX, z + offsetZ)) {
+        return false;
+    }
     return rsmod.canTravel(level, x, z, offsetX, offsetZ, size, extraFlag, collision);
 }
 

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -485,22 +485,6 @@ export default abstract class PathingEntity extends Entity {
                 return;
             }
             if (this.target instanceof PathingEntity) {
-                if (this.width > 1 && !CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
-                    // west/east
-                    let dir = CoordGrid.face(this.x, 0, this.target.x, 0);
-                    const distanceToTarget = CoordGrid.distanceTo({ x: this.x, z: this.z, width: this.width, length: this.length }, { x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length });
-                    if (canTravel(this.level, this.x, this.z, CoordGrid.deltaX(dir), 0, this.width, extraFlag, collisionStrategy) || distanceToTarget <= 1) {
-                        this.queueWaypoint(CoordGrid.moveX(this.x, dir), this.z);
-                        return;
-                    }
-                    // north/south
-                    dir = CoordGrid.face(0, this.z, 0, this.target.z);
-                    if (canTravel(this.level, this.x, this.z, 0, CoordGrid.deltaZ(dir), this.width, extraFlag, collisionStrategy)) {
-                        this.queueWaypoint(this.x, CoordGrid.moveZ(this.z, dir));
-                        return;
-                    }
-                    return;
-                }
                 this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, extraFlag, collisionStrategy));
             } else {
                 this.queueWaypoint(this.target.x, this.target.z);
@@ -636,19 +620,6 @@ export default abstract class PathingEntity extends Entity {
             return null;
         }
 
-        const srcX: number = this.x;
-        const srcZ: number = this.z;
-
-        const { x, z } = CoordGrid.unpackCoord(this.waypoints[this.waypointIndex]);
-        const dir: number = CoordGrid.face(srcX, srcZ, x, z);
-        const dx: number = CoordGrid.deltaX(dir);
-        const dz: number = CoordGrid.deltaZ(dir);
-
-        // check if moved off current pos.
-        if (dx == 0 && dz == 0) {
-            return -1;
-        }
-
         const collisionStrategy: CollisionType | null = this.getCollisionStrategy();
         if (collisionStrategy === null) {
             // nomove moverestrict returns as null = no walking allowed.
@@ -658,6 +629,32 @@ export default abstract class PathingEntity extends Entity {
         const extraFlag: CollisionFlag = this.blockWalkFlag();
         if (extraFlag === CollisionFlag.NULL) {
             // nomove moverestrict returns as null = no walking allowed.
+            return -1;
+        }
+
+        const srcX: number = this.x;
+        const srcZ: number = this.z;
+
+        const { x, z } = CoordGrid.unpackCoord(this.waypoints[this.waypointIndex]);
+
+        if (this.width > 1) {
+            const tryDirX = CoordGrid.face(srcX, 0, x, 0);
+            if (canTravel(this.level, srcX, srcZ, CoordGrid.deltaX(tryDirX), 0, this.width, extraFlag, collisionStrategy)) {
+                return tryDirX;
+            }
+            const tryDirZ = CoordGrid.face(0, srcZ, 0, z);
+            if (canTravel(this.level, srcX, srcZ, 0, CoordGrid.deltaZ(tryDirZ), this.width, extraFlag, collisionStrategy)) {
+                return tryDirZ;
+            }
+            return -1;
+        }
+
+        const dir: number = CoordGrid.face(srcX, srcZ, x, z);
+        const dx: number = CoordGrid.deltaX(dir);
+        const dz: number = CoordGrid.deltaZ(dir);
+
+        // check if moved off current pos.
+        if (dx == 0 && dz == 0) {
             return -1;
         }
 

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -662,10 +662,6 @@ export default abstract class PathingEntity extends Entity {
             return dir;
         }
 
-        if (!Environment.NODE_MEMBERS && !World.gameMap.isFreeToPlay(this.x + dx, this.z + dz)) {
-            return -1;
-        }
-
         // check current direction if can travel to chosen dest.
         if (canTravel(this.level, this.x, this.z, dx, dz, this.width, extraFlag, collisionStrategy)) {
             return dir;


### PR DESCRIPTION
For 225-244

It was previously thought that big npc's only pathed non-diagonally, if they were moving to a target. However, old videos indicate that it seemed to affect *all* of their movement? There's a whole lot of videos that showcase this behavior. Such as:
- https://youtu.be/Rpy_d7IkDfw
- https://youtu.be/Lbsmdm3Kuzc

To me the second video is as clear as day:

https://github.com/user-attachments/assets/24eae42e-7a91-4d25-b468-74d573bc7f2f

After our fixes, for reference:


https://github.com/user-attachments/assets/d7b35626-4766-496e-b3de-09765c8d7eb3



Additionally, there was a bug in F2P worlds, that prevented npc movement in certain situations when it shouldn't. This is extremely rare and probably has never been recreated before, but I'm fairly certain this behavior is inauthentic.

Before:

https://github.com/user-attachments/assets/63125e05-889d-42b6-85a5-a0ed3c20797f


After:

https://github.com/user-attachments/assets/d517a36b-4f11-427a-bc49-1c7422d8b719

