### PR TITLE
feat: allow if_setanim to take nulls

### DIFF
--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -657,11 +657,6 @@ const PlayerOps: CommandHandlers = {
 
         check(com, NumberNotNull);
 
-        if (seq === -1) {
-            // uh, client crashes! which means empty dialogue wasn't an option at the time
-            return;
-        }
-
         state.activePlayer.write(new IfSetAnim(com, seq));
     }),
 


### PR DESCRIPTION
Client now handles `seq = -1` by resetting the component anim:
```java
if (this.packetId == 2) {
    int componentId = this.packetBuffer.g2_alt3();
    int sequenceId = this.packetBuffer.g2b_alt2();
    Component component = Component.load(componentId);
    if (component.anim != sequenceId || sequenceId == -1) {
        component.anim = sequenceId;
        component.animFrame = 0;
        component.animCycle = 0;
    }
    this.packetId = -1;
    return true;
}
```