### PR TITLE
fix: preserve weakqueue when continuing or ending dialogue

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -742,9 +742,10 @@ export default class Player extends PathingEntity {
         }
     }
 
-    closeModal() {
-        this.weakQueue.clear();
-
+    closeModal(clearWeakQueue: boolean = true) {
+        if (clearWeakQueue) {
+            this.weakQueue.clear();
+        }
         if (!this.delayed) {
             this.protect = false;
         }
@@ -2135,7 +2136,7 @@ export default class Player extends PathingEntity {
 
             if ((this.modalState & ModalState.MAIN) === ModalState.NONE) {
                 // close chat dialogues automatically and leave main modals alone
-                this.closeModal();
+                this.closeModal(false);
             }
         }
     }


### PR DESCRIPTION
example: continuing a level up interface should not clear weakqueues