### PR TITLE
fix: use chebyshev distance for distance calculation in map_findsquare

### DIFF
--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -428,8 +428,8 @@ const ServerOps: CommandHandlers = {
                 for (let i = 0; i < 50; i++) {
                     const distX = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
                     const distZ = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
-                    const distanceSquared = distX * distX + distZ * distZ;
-                    if (distanceSquared < minRadius * minRadius || distanceSquared > maxRadius * maxRadius) {
+                    const distance = Math.max(Math.abs(distX), Math.abs(distZ));
+                    if (distance < minRadius || distance > maxRadius) {
                         continue;
                     }
                     const randomX = origin.x + distX;
@@ -446,8 +446,8 @@ const ServerOps: CommandHandlers = {
                 for (let i = 0; i < 50; i++) {
                     const distX = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
                     const distZ = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
-                    const distanceSquared = distX * distX + distZ * distZ;
-                    if (distanceSquared < minRadius * minRadius || distanceSquared > maxRadius * maxRadius) {
+                    const distance = Math.max(Math.abs(distX), Math.abs(distZ));
+                    if (distance < minRadius || distance > maxRadius) {
                         continue;
                     }
                     const randomX = origin.x + distX;
@@ -464,8 +464,8 @@ const ServerOps: CommandHandlers = {
                 for (let i = 0; i < 50; i++) {
                     const distX = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
                     const distZ = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
-                    const distanceSquared = distX * distX + distZ * distZ;
-                    if (distanceSquared < minRadius * minRadius || distanceSquared > maxRadius * maxRadius) {
+                    const distance = Math.max(Math.abs(distX), Math.abs(distZ));
+                    if (distance < minRadius || distance > maxRadius) {
                         continue;
                     }
                     const randomX = origin.x + distX;
@@ -485,8 +485,8 @@ const ServerOps: CommandHandlers = {
                 for (let x = origin.x - maxRadius; x <= origin.x + maxRadius; x++) {
                     const distX = x - origin.x;
                     const distZ = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
-                    const distanceSquared = distX * distX + distZ * distZ;
-                    if (distanceSquared < minRadius * minRadius || distanceSquared > maxRadius * maxRadius) {
+                    const distance = Math.max(Math.abs(distX), Math.abs(distZ));
+                    if (distance < minRadius || distance > maxRadius) {
                         continue;
                     }
                     const randomZ = origin.z + distZ;
@@ -502,8 +502,8 @@ const ServerOps: CommandHandlers = {
                 for (let x = origin.x - maxRadius; x <= origin.x + maxRadius; x++) {
                     const distX = x - origin.x;
                     const distZ = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
-                    const distanceSquared = distX * distX + distZ * distZ;
-                    if (distanceSquared < minRadius * minRadius || distanceSquared > maxRadius * maxRadius) {
+                    const distance = Math.max(Math.abs(distX), Math.abs(distZ));
+                    if (distance < minRadius || distance > maxRadius) {
                         continue;
                     }
                     const randomZ = origin.z + distZ;
@@ -519,8 +519,8 @@ const ServerOps: CommandHandlers = {
                 for (let x = origin.x - maxRadius; x <= origin.x + maxRadius; x++) {
                     const distX = x - origin.x;
                     const distZ = Math.floor(Math.random() * (2 * maxRadius + 1)) - maxRadius;
-                    const distanceSquared = distX * distX + distZ * distZ;
-                    if (distanceSquared < minRadius * minRadius || distanceSquared > maxRadius * maxRadius) {
+                    const distance = Math.max(Math.abs(distX), Math.abs(distZ));
+                    if (distance < minRadius || distance > maxRadius) {
                         continue;
                     }
                     const randomZ = origin.z + distZ;


### PR DESCRIPTION
for all engine versions

currently, the map_findsquare command uses Euclidean distance to determine if a tile is within the min/max radius bounds, this will result in tiles that are within radius being counted out (for example, maxRadius 1 will only have cardinally adjacent tiles rather than including the diagonals, or as another example, if a tile is 4 away in both directions, it's euclidian dist is ~5.6, which means it wont even be in bounds for maxradius 5). Based off testing, this doesn't seem to match OSRS (comparing with some of the 1,1 checks, and 0,2 which teleports use). It can be fixed by calculating Chebyshev distance instead for the comparison