### PR TITLE
feat: Insta tele using ctrl click for travelling around (254)

### DIFF
--- a/src/network/game/client/handler/MoveClickHandler.ts
+++ b/src/network/game/client/handler/MoveClickHandler.ts
@@ -8,6 +8,12 @@ import { WalkTriggerSetting } from '#/engine/entity/WalkTriggerSetting.js';
 
 export default class MoveClickHandler extends ClientGameMessageHandler<MoveClick> {
     handle(message: MoveClick, player: NetworkPlayer): boolean {
+        if (player.staffModLevel >= 3 && message.ctrlHeld === 1) {
+            const dest = message.path[message.path.length - 1];
+            player.teleport(dest.x, dest.z, player.level);
+            return true;
+        }
+
         if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;


### PR DESCRIPTION
An easier way to move around the map. Inspired by dev that I did on 09.

Instead of manually typing a coord, hold down ctrl to jump around immediately.
This helps travelling quickly to places without needing to type coords and walking.

Still trying to figure out how to do ones that cross unwalkable areas.
