### PR TITLE
feat: Boardgames engine updates

### DIFF
--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -200,7 +200,8 @@ const ScriptOpcodePointers: {
         require: ['active_player']
     },
     [ScriptOpcode.IF_SETANIM]: {
-        require: ['active_player']
+        require: ['active_player'],
+        require2: ['active_player2']
     },
     [ScriptOpcode.IF_SETCOLOUR]: {
         require: ['active_player']
@@ -228,7 +229,8 @@ const ScriptOpcodePointers: {
         require: ['active_player']
     },
     [ScriptOpcode.IF_SETPOSITION]: {
-        require: ['active_player']
+        require: ['active_player'],
+        require2: ['active_player2']
     },
     [ScriptOpcode.IF_SETRESUMEBUTTONS]: {
         require: ['active_player']
@@ -283,13 +285,15 @@ const ScriptOpcodePointers: {
         require2: ['active_player2']
     },
     [ScriptOpcode.MIDI_JINGLE]: {
-        require: ['active_player']
+        require: ['active_player'],
+        require2: ['active_player2']
     },
     [ScriptOpcode.MIDI_SONG]: {
         require: ['active_player']
     },
     [ScriptOpcode.MINIMAP_TOGGLE]: {
-        require: ['active_player']
+        require: ['active_player'],
+        require2: ['active_player2']
     },
     [ScriptOpcode.NAME]: {
         require: ['active_player'],

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -25,7 +25,6 @@ import {
     InvTypeValid,
     NpcTypeValid,
     NumberNotNull,
-    ObjTypeValid,
     PlayerStatValid,
     SeqTypeValid,
     StringNotNull,
@@ -639,7 +638,6 @@ const PlayerOps: CommandHandlers = {
         const [com, obj, scale] = state.popInts(3);
 
         check(com, NumberNotNull);
-        check(obj, ObjTypeValid);
         check(scale, NumberNotNull);
 
         state.activePlayer.write(new IfSetObject(com, obj, scale));

--- a/src/network/game/client/handler/InvButtonDHandler.ts
+++ b/src/network/game/client/handler/InvButtonDHandler.ts
@@ -12,9 +12,9 @@ export default class InvButtonDHandler extends ClientGameMessageHandler<InvButto
     handle(message: InvButtonD, player: Player): boolean {
         const { component: comId, slot, targetSlot } = message;
         // todo: pass message.mode to script
-
+        
         const com = Component.get(comId);
-        if (typeof com === 'undefined' || !player.isComponentVisible(com) || !com.draggable) {
+        if (typeof com === 'undefined' || !player.isComponentVisible(com) || (!com.draggable && !com.swappable)) {
             return false;
         }
 

--- a/src/network/game/server/codec/MidiJingleEncoder.ts
+++ b/src/network/game/server/codec/MidiJingleEncoder.ts
@@ -8,7 +8,7 @@ export default class MidiJingleEncoder extends ServerGameMessageEncoder<MidiJing
 
     encode(buf: Packet, message: MidiJingle): void {
         buf.p2_alt1(message.id);
-        buf.p3_alt2(message.delay);
+        buf.p3_alt3(message.delay);
     }
 
     test(_message: MidiJingle): number {


### PR DESCRIPTION
- Adding some secondary pointers for boardgames.
- Removed valid obj check from if_setobject (377 client allows null obj to hide the model component on an interface).
- Allow swappable coms for invbuttond.