### PR TITLE
feat: (FontType) Preserve tags on new lines

### DIFF
--- a/src/cache/config/FontType.ts
+++ b/src/cache/config/FontType.ts
@@ -127,7 +127,7 @@ export default class FontType {
 
         let size = 0;
         for (let c = 0; c < str.length; c++) {
-            if (str.charAt(c) == '@' && c + 4 < str.length && str.charAt(c + 4) == '@') {
+            if (this.isTag(str.substring(c, c + 5))) {
                 c += 4;
             } else {
                 size += this.drawWidth[str.charCodeAt(c)];
@@ -154,6 +154,7 @@ export default class FontType {
 
             // we need to split on the next word boundary
             let splitIndex = str.length;
+            let isManualBreak = false;
 
             // check the width at every space to see where we can cut the line
             for (let i = 0; i < str.length; i++) {
@@ -165,13 +166,39 @@ export default class FontType {
                     splitIndex = i;
                 } else if (str[i] === '|') {
                     splitIndex = i;
+                    isManualBreak = true;
                     break;
                 }
             }
 
-            lines.push(str.substring(0, splitIndex));
-            str = str.substring(splitIndex + 1);
+            const currentLine = str.substring(0, splitIndex);
+            lines.push(currentLine);
+            const remaining = str.substring(splitIndex + 1);
+
+            // preserve tags on new line, @str@ only across automatic breaks
+            let lastTag = '';
+            let strikeThrough = false;
+            for (let c = 0; c <= splitIndex; c++) {
+                const tag = currentLine.substring(c, c + 5);
+                if (this.isTag(tag)) {
+                    if (tag == '@str@') {
+                        strikeThrough = true;
+                    } else {
+                        lastTag = tag;
+                    }
+                    c += 4;
+                }
+            }
+            if (this.isTag(remaining.trimStart().substring(0, 5))) {
+                str = remaining;
+            } else {
+                str = ((strikeThrough && !isManualBreak) ? '@str@' : lastTag) + remaining;
+            }
         }
         return lines;
+    }
+
+    isTag(str: string): boolean {
+        return str.length == 5 && str.charAt(0) == '@' && str.charAt(4) == '@';
     }
 }


### PR DESCRIPTION
WIP until reviewed, otherwise works good in my testing.

- For 254+

Currently, while using `split_init` and `split_get` (in quest journals specifically)
You have to readd a text decorator tag (`@dre@, @dbl@, @str@, etc`) on every new line, whether it's an automatic split based on length or manual with a `|`.

I think this should be adjusted so that every new line should carry over the last tag of the previous line based on line breaks in quest journals and interface size changes over time. The strikethrough tag should only carry over through automatic line breaks, not manual line breaks. Below is an example.

---
Step 10 - RS3:
<img width="400" height="98" alt="image" src="https://github.com/user-attachments/assets/1dc90b64-fc78-4d22-b985-4a8590cf4957" />
Step 10 - OSRS:
<img width="484" height="140" alt="image" src="https://github.com/user-attachments/assets/8e127fe4-c2b1-4a86-a851-6748441cb31a" />

Step 20 - RS3:
<img width="400" height="140" alt="image" src="https://github.com/user-attachments/assets/f04d0560-7b84-420a-991b-de8e8a379a6c" />
Step 20 - OSRS:
<img width="491" height="221" alt="image" src="https://github.com/user-attachments/assets/d13259c2-c70a-4d31-8fd2-4223f81bf67a" />

Based on these screenshots, it would appear that the line breaks are only inserted at the end of a phrase/paragraph (in the above example, the word "fear."), rather than manually. I have doubts that these journals were all reworked each time the interface changed to make the line breaks fit properly (and maintaining formatting).

To do this currently:
Step 10: `@dre@Lucien@dbl@ has asked me to retrieve the @dre@Staff of Armadyl@dbl@ from|@dbl@the @dre@Temple of Ikov@dbl@. The entrance is near @dre@Hemenster@dbl@. He has|@dbl@given me a @dre@pendant@dbl@ so I can enter the @dre@chamber of fear.`
Step 20: `@str@Lucien has asked me to retrieve the Staff of Armadyl from|@str@the Temple of Ikov. The entrance is near Hemenster. He has|@str@given me a pendant so I can enter the chamber of fear.`

After this PR:
Step 10: `@dre@Lucien@dbl@ has asked me to retrieve the @dre@Staff of Armadyl@dbl@ from the @dre@Temple of Ikov@dbl@. The entrance is near @dre@Hemenster@dbl@. He has given me a @dre@pendant@dbl@ so I can enter the @dre@chamber of fear.`
Step 20: `@str@Lucien has asked me to retrieve the Staff of Armadyl from the Temple of Ikov. The entrance is near Hemenster. He has given me a pendant so I can enter the chamber of fear.`

