### PR TITLE
fix: simplify friend server profile handling

### DIFF
--- a/src/server/friend/FriendServer.ts
+++ b/src/server/friend/FriendServer.ts
@@ -61,16 +61,14 @@ const WORLD_PLAYER_LIMIT = 2000;
  */
 export class FriendServer {
     private server: WebSocketServer;
+    
+    private profile: string = Environment.NODE_PROFILE;
+    private repository: FriendServerRepository = new FriendServerRepository(this.profile);
 
     /**
-     * repositories[profile] = repository
+     * socketByWorld[worldId] = socket
      */
-    private repositories: Record<string, FriendServerRepository> = {};
-
-    /**
-     * socketByWorld[profile][worldId] = socket
-     */
-    private socketByWorld: Record<string, Record<number, WebSocket>> = {};
+    private socketByWorld: Record<number, WebSocket> = {};
 
     constructor() {
         this.server = new WebSocketServer({ port: Environment.FRIEND_PORT, host: '0.0.0.0' }, () => {
@@ -79,10 +77,9 @@ export class FriendServer {
 
         this.server.on('connection', (socket: WebSocket) => {
             /**
-             * The world number and profile for this connection. This is set when the world sends a WORLD_CONNECT packet.
+             * The world number for this connection. This is set when the world sends a WORLD_CONNECT packet.
              */
             let world: number | null = null;
-            let profile: string | null = null;
 
             socket.on('message', async (buf: Buffer) => {
                 try {
@@ -96,17 +93,22 @@ export class FriendServer {
                         }
 
                         world = message.world as number;
-                        profile = message.profile as string;
+                        const profile = message.profile as string;
 
-                        this.initializeWorld(profile, world, socket);
+                        if (profile === undefined || profile !== this.profile) {
+                            socket.close();
+                            console.error(`[Friends]: World ${world} tried to connect with incorrect profile: ${profile}`);
+                            return;
+                        }
+
+                        this.initializeWorld(world, socket);
 
                         // printDebug(`[Friends]: World ${world} connected`);
                     } else if (type === FriendsClientOpcodes.PLAYER_LOGIN) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received PLAYER_LOGIN before WORLD_CONNECT');
                             // return;
@@ -121,9 +123,9 @@ export class FriendServer {
                         }
 
                         // remove player from previous world, if any
-                        this.repositories[profile].unregister(username37);
+                        this.repository.unregister(username37);
 
-                        if (!(await this.repositories[profile].register(world, username37, privateChat, message.staffLvl))) {
+                        if (!(await this.repository.register(world, username37, privateChat, message.staffLvl))) {
                             // TODO handle this better?
                             // console.error(`[Friends]: World ${world} is full`);
                             return;
@@ -133,17 +135,16 @@ export class FriendServer {
 
                         // notify the player who just logged in about their friends
                         // we can use `socket` here because we know the player is connected to this world
-                        await this.sendFriendsListToPlayer(profile, username37, socket);
-                        await this.sendIgnoreListToPlayer(profile, username37, socket);
+                        await this.sendFriendsListToPlayer(username37, socket);
+                        await this.sendIgnoreListToPlayer(username37, socket);
 
                         // notify all friends of the player who just logged in
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.PLAYER_LOGOUT) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received PLAYER_LOGOUT before WORLD_CONNECT');
                             // return;
@@ -155,15 +156,14 @@ export class FriendServer {
                         // printDebug(`[Friends]: Player ${username} logged out of world ${world}`);
 
                         // remove player from previous world, if any
-                        this.repositories[profile].unregister(username37);
+                        this.repository.unregister(username37);
 
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.PLAYER_CHAT_SETMODE) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received PLAYER_CHAT_SETMODE before WORLD_CONNECT');
                             // return;
@@ -180,14 +180,13 @@ export class FriendServer {
 
                         // printDebug(`[Friends]: Player ${username} set chat mode to ${privateChat}`);
 
-                        this.repositories[profile].setChatMode(username37, privateChat);
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        this.repository.setChatMode(username37, privateChat);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.FRIENDLIST_ADD) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received FRIENDLIST_ADD before WORLD_CONNECT');
                             // return;
@@ -196,19 +195,18 @@ export class FriendServer {
                         const username37 = BigInt(message.username37);
                         const targetUsername37 = BigInt(message.targetUsername37);
 
-                        await this.repositories[profile].addFriend(username37, targetUsername37);
+                        await this.repository.addFriend(username37, targetUsername37);
 
-                        await this.sendPlayerWorldUpdate(profile, username37, targetUsername37);
+                        await this.sendPlayerWorldUpdate(username37, targetUsername37);
 
                         // we can refactor this to only send the update to the new friend
                         // currently we broadcast this in case the player has private chat set to "Friends"
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.FRIENDLIST_DEL) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received FRIENDLIST_DEL before WORLD_CONNECT');
                             // return;
@@ -217,16 +215,15 @@ export class FriendServer {
                         const username37 = BigInt(message.username37);
                         const targetUsername37 = BigInt(message.targetUsername37);
 
-                        await this.repositories[profile].deleteFriend(username37, targetUsername37);
+                        await this.repository.deleteFriend(username37, targetUsername37);
 
                         // we can refactor this to only send the update to the ex-friend
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.IGNORELIST_ADD) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received IGNORELIST_ADD before WORLD_CONNECT');
                             // return;
@@ -235,16 +232,15 @@ export class FriendServer {
                         const username37 = BigInt(message.username37);
                         const targetUsername37 = BigInt(message.targetUsername37);
 
-                        await this.repositories[profile].addIgnore(username37, targetUsername37);
+                        await this.repository.addIgnore(username37, targetUsername37);
 
                         // we can refactor this to only send the update to the player who was added to the ignore list
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.IGNORELIST_DEL) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Received IGNORELIST_DEL before WORLD_CONNECT');
                             // return;
@@ -253,16 +249,15 @@ export class FriendServer {
                         const username37 = BigInt(message.username37);
                         const targetUsername37 = BigInt(message.targetUsername37);
 
-                        await this.repositories[profile].deleteIgnore(username37, targetUsername37);
+                        await this.repository.deleteIgnore(username37, targetUsername37);
 
                         // we can refactor this to only send the update to the player who was removed from the ignore list
-                        await this.broadcastWorldToFollowers(profile, username37);
+                        await this.broadcastWorldToFollowers(username37);
                     } else if (type === FriendsClientOpcodes.PRIVATE_MESSAGE) {
-                        if (world === null || profile === null) {
+                        if (world === null) {
                             world = message.world as number;
-                            profile = message.profile as string;
 
-                            this.initializeWorld(profile, world, socket);
+                            this.initializeWorld(world, socket);
 
                             // console.error('[Friends]: Recieved PRIVATE_MESSAGE before WORLD_CONNECT');
                             // return;
@@ -287,7 +282,7 @@ export class FriendServer {
                             })
                             .execute();
 
-                        await this.sendPrivateMessage(profile, username37, staffLvl, pmId, targetUsername37, chat);
+                        await this.sendPrivateMessage(username37, staffLvl, pmId, targetUsername37, chat);
                     } else if (type === FriendsClientOpcodes.PUBLIC_CHAT_LOG) {
                         const { nodeId, nodeTime, profile, username, coord, chat } = message;
 
@@ -306,11 +301,10 @@ export class FriendServer {
                             })
                             .execute();
                     } else if (type === FriendsClientOpcodes.RELAY_MUTE) {
-                        const { profile, nodeId, username, muted_until } = message;
+                        const { nodeId, username, muted_until } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_MUTE,
                                     username,
@@ -319,11 +313,10 @@ export class FriendServer {
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_KICK) {
-                        const { profile, nodeId, username } = message;
+                        const { nodeId, username } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_KICK,
                                     username
@@ -331,11 +324,10 @@ export class FriendServer {
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_SHUTDOWN) {
-                        const { profile, nodeId, duration } = message;
+                        const { nodeId, duration } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_SHUTDOWN,
                                     duration
@@ -343,11 +335,10 @@ export class FriendServer {
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_BROADCAST) {
-                        const { profile, nodeId, broadcast } = message;
+                        const { nodeId, broadcast } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_BROADCAST,
                                     message: broadcast
@@ -355,11 +346,10 @@ export class FriendServer {
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_TRACK) {
-                        const { profile, nodeId, username, state } = message;
+                        const { nodeId, username, state } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_TRACK,
                                     username,
@@ -368,44 +358,40 @@ export class FriendServer {
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_RELOAD) {
-                        const { profile, nodeId } = message;
+                        const { nodeId } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_RELOAD
                                 })
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_CLEARLOGINS) {
-                        const { profile, nodeId } = message;
+                        const { nodeId } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_CLEARLOGINS
                                 })
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_CLEARLOGOUTS) {
-                        const { profile, nodeId } = message;
+                        const { nodeId } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_CLEARLOGOUTS
                                 })
                             );
                         }
                     } else if (type === FriendsClientOpcodes.RELAY_QUEUESCRIPT) {
-                        const { profile, nodeId, scriptName, username } = message;
+                        const { nodeId, scriptName, username } = message;
 
-                        if (typeof this.socketByWorld[profile] !== 'undefined'
-                            && typeof this.socketByWorld[profile][nodeId] !== 'undefined') {
-                            this.socketByWorld[profile][nodeId].send(
+                        if (typeof this.socketByWorld[nodeId] !== 'undefined') {
+                            this.socketByWorld[nodeId].send(
                                 JSON.stringify({
                                     type: FriendsServerOpcodes.RELAY_QUEUESCRIPT,
                                     scriptName,
@@ -428,26 +414,17 @@ export class FriendServer {
 
     async start() {}
 
-    private async initializeWorld(profile: string, world: number, socket: WebSocket) {
-        if (!this.socketByWorld[profile]) {
-            this.socketByWorld[profile] = {};
+    private async initializeWorld(world: number, socket: WebSocket) {
+        if (this.socketByWorld[world]) {
+            this.socketByWorld[world].terminate();
         }
 
-        if (this.socketByWorld[profile][world]) {
-            this.socketByWorld[profile][world].terminate();
-        }
-
-        this.socketByWorld[profile][world] = socket;
-
-        if (!this.repositories[profile]) {
-            this.repositories[profile] = new FriendServerRepository(profile);
-        }
-
-        this.repositories[profile].initializeWorld(world, WORLD_PLAYER_LIMIT);
+        this.socketByWorld[world] = socket;
+        this.repository.initializeWorld(world, WORLD_PLAYER_LIMIT);
     }
 
-    private async sendFriendsListToPlayer(profile: string, username37: bigint, socket: WebSocket) {
-        const playerFriends = await this.repositories[profile].getFriends(username37);
+    private async sendFriendsListToPlayer(username37: bigint, socket: WebSocket) {
+        const playerFriends = await this.repository.getFriends(username37);
 
         socket.send(
             JSON.stringify({
@@ -458,8 +435,8 @@ export class FriendServer {
         );
     }
 
-    private async sendIgnoreListToPlayer(profile: string, username37: bigint, socket: WebSocket) {
-        const playerIgnores = await this.repositories[profile].getIgnores(username37);
+    private async sendIgnoreListToPlayer(username37: bigint, socket: WebSocket) {
+        const playerIgnores = await this.repository.getIgnores(username37);
 
         socket.send(
             JSON.stringify({
@@ -470,43 +447,43 @@ export class FriendServer {
         );
     }
 
-    private async broadcastWorldToFollowers(profile: string, username37: bigint) {
-        const followers = this.repositories[profile].getFollowers(username37);
+    private async broadcastWorldToFollowers(username37: bigint) {
+        const followers = this.repository.getFollowers(username37);
 
         for (const follower of followers) {
-            await this.sendPlayerWorldUpdate(profile, follower, username37);
+            await this.sendPlayerWorldUpdate(follower, username37);
         }
     }
 
-    private getPlayerWorldSocket(profile: string, username: bigint) {
-        const world = this.repositories[profile].getWorld(username);
+    private getPlayerWorldSocket(username: bigint) {
+        const world = this.repository.getWorld(username);
         if (!world) {
             return null;
         }
 
-        return this.socketByWorld[profile][world] ?? null;
+        return this.socketByWorld[world] ?? null;
     }
 
-    private sendPlayerWorldUpdate(profile: string, viewer: bigint, other: bigint) {
-        const socket = this.getPlayerWorldSocket(profile, viewer);
+    private sendPlayerWorldUpdate(viewer: bigint, other: bigint) {
+        const socket = this.getPlayerWorldSocket(viewer);
 
         if (!socket) {
             return Promise.resolve();
         }
 
-        const otherPlayerWorld = this.repositories[profile].getWorld(other);
+        const otherPlayerWorld = this.repository.getWorld(other);
 
         socket.send(
             JSON.stringify({
                 type: FriendsServerOpcodes.UPDATE_FRIENDLIST,
                 username37: viewer.toString(),
-                friends: [[this.repositories[profile].isVisibleTo(viewer, other) ? otherPlayerWorld : 0, other.toString()]]
+                friends: [[this.repository.isVisibleTo(viewer, other) ? otherPlayerWorld : 0, other.toString()]]
             })
         );
     }
 
-    private sendPrivateMessage(profile: string, username: bigint, staffLvl: number, pmId: number, target: bigint, chat: string) {
-        const socket = this.getPlayerWorldSocket(profile, target);
+    private sendPrivateMessage(username: bigint, staffLvl: number, pmId: number, target: bigint, chat: string) {
+        const socket = this.getPlayerWorldSocket(target);
 
         if (!socket) {
             return Promise.resolve();
@@ -563,7 +540,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.PLAYER_LOGIN,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString(),
                 privateChat,
                 staffLvl
@@ -582,7 +558,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.PLAYER_LOGOUT,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString()
             })
         );
@@ -599,7 +574,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.FRIENDLIST_ADD,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString(),
                 targetUsername37: target.toString()
             })
@@ -617,7 +591,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.FRIENDLIST_DEL,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString(),
                 targetUsername37: target.toString()
             })
@@ -635,7 +608,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.IGNORELIST_ADD,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString(),
                 targetUsername37: target.toString()
             })
@@ -653,7 +625,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.IGNORELIST_DEL,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString(),
                 targetUsername37: target.toString()
             })
@@ -671,7 +642,6 @@ export class FriendClient extends InternalClient {
             JSON.stringify({
                 type: FriendsClientOpcodes.PLAYER_CHAT_SETMODE,
                 world: this.nodeId,
-                profile: this.profile,
                 username37: toBase37(username).toString(),
                 privateChat: privateChatMode
             })


### PR DESCRIPTION
Since we are not supporting cross-profile messaging, run a separate instance of the friend server for each profile. This will simplify rev differences required for the friend server such as friend list limits.