### PR TITLE
fix: Correct auto-resize to always fit window

### DIFF
--- a/view/client.ejs
+++ b/view/client.ejs
@@ -231,8 +231,6 @@
                 case 'auto':
                     canvas.style.width = '100%';
                     canvas.style.height = 'auto';
-                    let maxWidth = ((window.innerHeight - 120) / 503) * 765;
-                    canvas.style.maxWidth = maxWidth + 'px';
                     break;
             }
             document.getElementById('size').value = size;


### PR DESCRIPTION
Auto resize failed after page refresh / world reload & left the canvas constrained by a max width.