### PR TITLE
fix: persist current step for large entities if blocked

### DIFF
--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -654,7 +654,7 @@ export default abstract class PathingEntity extends Entity {
             if (canTravel(this.level, srcX, srcZ, 0, CoordGrid.deltaZ(tryDirZ), this.width, extraFlag, collisionStrategy)) {
                 return tryDirZ;
             }
-            return -1;
+            return null;
         }
 
         const dir: number = CoordGrid.face(srcX, srcZ, x, z);


### PR DESCRIPTION
Currently, when a large (width > 1) PathingEntitys next step is blocked, it skips to the next waypoint (which stops movement if that was the only waypoint), this isn't in line with OSRS or what 1x1's do, so this PR changes it to match