### PR TITLE
feat: tutorial island check in stat_advance

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -2139,6 +2139,16 @@ export default class Player extends PathingEntity {
         }
     }
 
+    isInTutorial(): boolean {
+        if (this.x >= 3053 && this.x <= 3156 && this.z >= 3056 && this.z <= 3136) {
+            return true;
+        } else if (this.x >= 3072 && this.x <= 3118 && this.z >= 9492 && this.z <= 9535) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     // ----
 
     runScript(script: ScriptState, protect: boolean = false, force: boolean = false) {

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -768,8 +768,12 @@ const PlayerOps: CommandHandlers = {
 
         check(stat, NumberNotNull);
         check(xp, NumberNotNull);
-
-        state.activePlayer.addXp(stat, xp);
+        // Maybe this can go into addXp? Not sure
+        const player = state.activePlayer;
+        if (player.levels[stat] >= 3 && player.isInTutorial()) {
+            return;
+        }
+        player.addXp(stat, xp);
     }),
 
     [ScriptOpcode.DAMAGE]: state => {


### PR DESCRIPTION
for 225+

Old bugs in osrs indicate that all xp, even quest reward xp, is blocked on tutorial island. This doesnt really make sense in osrs if the tutorial island check is content. Osrs has two forms of xp, regular xp and reward xp (likely two different procs). Seems strange to add tutorial island checks to both procs. Engine limitation sounds much more plausible.