### PR TITLE
fix: remove moverestrict as a PathingEntity field

### DIFF
--- a/src/engine/GameMap.ts
+++ b/src/engine/GameMap.ts
@@ -131,7 +131,7 @@ export default class GameMap {
                 }
                 if ((npcType.members && this.members) || !npcType.members) {
                     const size: number = npcType.size;
-                    const npc: Npc = new Npc(level, absoluteX, absoluteZ, size, size, EntityLifeCycle.RESPAWN, World.getNextNid(), npcType.id, npcType.moverestrict, npcType.blockwalk);
+                    const npc: Npc = new Npc(level, absoluteX, absoluteZ, size, size, EntityLifeCycle.RESPAWN, World.getNextNid(), npcType.id, npcType.blockwalk);
                     World.addNpc(npc, -1);
                 }
             }

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -75,8 +75,8 @@ export default class Npc extends PathingEntity {
 
     heroPoints: HeroPoints = new HeroPoints(16); // be sure to reset when stats are recovered/reset
 
-    constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, nid: number, type: number, moveRestrict: MoveRestrict, blockWalk: BlockWalk) {
-        super(level, x, z, width, length, lifecycle, moveRestrict, blockWalk, MoveStrategy.NAIVE, NpcInfoProt.FACE_COORD, NpcInfoProt.FACE_ENTITY);
+    constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, nid: number, type: number, blockWalk: BlockWalk) {
+        super(level, x, z, width, length, lifecycle, blockWalk, MoveStrategy.NAIVE, NpcInfoProt.FACE_COORD, NpcInfoProt.FACE_ENTITY);
         this.nid = nid;
         this.baseType = type;
         this.type = type;
@@ -381,19 +381,20 @@ export default class Npc extends PathingEntity {
     }
 
     blockWalkFlag(): CollisionFlag {
-        if (this.moveRestrict === MoveRestrict.NORMAL) {
+        const type: NpcType = NpcType.get(this.type);
+        if (type.moverestrict === MoveRestrict.NORMAL) {
             return CollisionFlag.NPC;
-        } else if (this.moveRestrict === MoveRestrict.BLOCKED) {
+        } else if (type.moverestrict === MoveRestrict.BLOCKED) {
             return CollisionFlag.OPEN;
-        } else if (this.moveRestrict === MoveRestrict.BLOCKED_NORMAL) {
+        } else if (type.moverestrict === MoveRestrict.BLOCKED_NORMAL) {
             return CollisionFlag.NPC;
-        } else if (this.moveRestrict === MoveRestrict.INDOORS) {
+        } else if (type.moverestrict === MoveRestrict.INDOORS) {
             return CollisionFlag.NPC;
-        } else if (this.moveRestrict === MoveRestrict.OUTDOORS) {
+        } else if (type.moverestrict === MoveRestrict.OUTDOORS) {
             return CollisionFlag.NPC;
-        } else if (this.moveRestrict === MoveRestrict.NOMOVE) {
+        } else if (type.moverestrict === MoveRestrict.NOMOVE) {
             return CollisionFlag.NULL;
-        } else if (this.moveRestrict === MoveRestrict.PASSTHRU) {
+        } else if (type.moverestrict === MoveRestrict.PASSTHRU) {
             return CollisionFlag.OPEN;
         }
         return CollisionFlag.NULL;
@@ -430,9 +431,10 @@ export default class Npc extends PathingEntity {
         this.masks |= NpcInfoProt.CHANGE_TYPE;
         this.uid = (type << 16) | this.nid;
         this.resetOnRevert = reset;
+        
+        const npcType = NpcType.get(type);
 
         if (reset) {
-            const npcType = NpcType.get(type);
             for (let index = 0; index < npcType.stats.length; index++) {
                 const level = npcType.stats[index];
                 this.levels[index] = Math.max(level - (this.baseLevels[index] - this.levels[index]), 0);

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -19,6 +19,7 @@ import Player from '#/engine/entity/Player.js';
 import { canTravel, changeNpcCollision, changePlayerCollision, findPath, findPathToEntity, findPathToLoc, isApproached, isZoneAllocated, reachedEntity, reachedLoc, reachedObj, findNaivePath } from '#/engine/GameMap.js';
 import ServerTriggerType from '#/engine/script/ServerTriggerType.js';
 import World from '#/engine/World.js';
+import NpcType from '#/cache/config/NpcType.js';
 
 type TargetSubject = {
     type: number;
@@ -29,7 +30,6 @@ export type TargetOp = ServerTriggerType | NpcMode;
 
 export default abstract class PathingEntity extends Entity {
     // constructor properties
-    protected readonly moveRestrict: MoveRestrict;
     blockWalk: BlockWalk;
     moveStrategy: MoveStrategy;
     private readonly coordmask: number;
@@ -102,9 +102,8 @@ export default abstract class PathingEntity extends Entity {
     spotanimHeight: number = -1;
     spotanimTime: number = -1;
 
-    protected constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, moveRestrict: MoveRestrict, blockWalk: BlockWalk, moveStrategy: MoveStrategy, coordmask: number, entitymask: number) {
+    protected constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, blockWalk: BlockWalk, moveStrategy: MoveStrategy, coordmask: number, entitymask: number) {
         super(level, x, z, width, length, lifecycle);
-        this.moveRestrict = moveRestrict;
         this.blockWalk = blockWalk;
         this.moveStrategy = moveStrategy;
         this.coordmask = coordmask;
@@ -566,22 +565,25 @@ export default abstract class PathingEntity extends Entity {
     }
 
     protected getCollisionStrategy(): CollisionType | null {
-        if (this.moveRestrict === MoveRestrict.NORMAL) {
-            return CollisionType.NORMAL;
-        } else if (this.moveRestrict === MoveRestrict.BLOCKED) {
-            return CollisionType.BLOCKED;
-        } else if (this.moveRestrict === MoveRestrict.BLOCKED_NORMAL) {
-            return CollisionType.LINE_OF_SIGHT;
-        } else if (this.moveRestrict === MoveRestrict.INDOORS) {
-            return CollisionType.INDOORS;
-        } else if (this.moveRestrict === MoveRestrict.OUTDOORS) {
-            return CollisionType.OUTDOORS;
-        } else if (this.moveRestrict === MoveRestrict.NOMOVE) {
-            return null;
-        } else if (this.moveRestrict === MoveRestrict.PASSTHRU) {
-            return CollisionType.NORMAL;
+        if(this instanceof Npc) {
+            const type: NpcType = NpcType.get(this.type);
+            if (type.moverestrict === MoveRestrict.NORMAL) {
+                return CollisionType.NORMAL;
+            } else if (type.moverestrict === MoveRestrict.BLOCKED) {
+                return CollisionType.BLOCKED;
+            } else if (type.moverestrict === MoveRestrict.BLOCKED_NORMAL) {
+                return CollisionType.LINE_OF_SIGHT;
+            } else if (type.moverestrict === MoveRestrict.INDOORS) {
+                return CollisionType.INDOORS;
+            } else if (type.moverestrict === MoveRestrict.OUTDOORS) {
+                return CollisionType.OUTDOORS;
+            } else if (type.moverestrict === MoveRestrict.NOMOVE) {
+                return null;
+            } else if (type.moverestrict === MoveRestrict.PASSTHRU) {
+                return CollisionType.NORMAL;
+            }
         }
-        return null;
+        return CollisionType.NORMAL;
     }
 
     protected resetPathingEntity(): void {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -25,7 +25,6 @@ import HeroPoints from '#/engine/entity/HeroPoints.js';
 import Loc from '#/engine/entity/Loc.js';
 import { ModalState } from '#/engine/entity/ModalState.js';
 import { AllowRepath } from './AllowRepath.js';
-import { MoveRestrict } from '#/engine/entity/MoveRestrict.js';
 import { MoveSpeed } from '#/engine/entity/MoveSpeed.js';
 import { MoveStrategy } from '#/engine/entity/MoveStrategy.js';
 import { isClientConnected } from '#/engine/entity/NetworkPlayer.js';
@@ -421,7 +420,6 @@ export default class Player extends PathingEntity {
             1,
             1,
             EntityLifeCycle.FOREVER,
-            MoveRestrict.NORMAL,
             BlockWalk.NPC,
             Environment.NODE_CLIENT_ROUTEFINDER ? MoveStrategy.NAIVE : MoveStrategy.SMART,
             PlayerInfoProt.FACE_COORD,

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -46,7 +46,7 @@ const NpcOps: CommandHandlers = {
         const npcType: NpcType = check(id, NpcTypeValid);
         check(duration, DurationValid);
 
-        const npc = new Npc(position.level, position.x, position.z, npcType.size, npcType.size, EntityLifeCycle.DESPAWN, World.getNextNid(), npcType.id, npcType.moverestrict, npcType.blockwalk);
+        const npc = new Npc(position.level, position.x, position.z, npcType.size, npcType.size, EntityLifeCycle.DESPAWN, World.getNextNid(), npcType.id, npcType.blockwalk);
         World.addNpc(npc, duration);
         state.activeNpc = npc;
         state.pointerAdd(ActiveNpc[state.intOperand]);

--- a/src/network/game/client/handler/ClientCheatHandler.ts
+++ b/src/network/game/client/handler/ClientCheatHandler.ts
@@ -513,7 +513,7 @@ export default class ClientCheatHandler extends ClientGameMessageHandler<ClientC
                 if (!type) {
                     return false;
                 }
-                World.addNpc(new Npc(player.level, player.x, player.z, type.size, type.size, EntityLifeCycle.DESPAWN, World.getNextNid(), type.id, type.moverestrict, type.blockwalk), 500);
+                World.addNpc(new Npc(player.level, player.x, player.z, type.size, type.size, EntityLifeCycle.DESPAWN, World.getNextNid(), type.id, type.blockwalk), 500);
             } else if (cmd === 'openmain') {
                 if (args.length < 1) {
                     return false;


### PR DESCRIPTION
for 225+

Currently, npcs that have changed type will use their old moverestrict, this is because there is a moverestrict field on PathingEntity itself, which isn't really necessary since players can only have 1 moverestrict anyways. To fix this, we can remove this field from PathingEntity and stick to the moverestrict field under NpcType as a source of truth instead