### PR TITLE
fix: more reliably check for locs in map_locaddunsafe

### DIFF
--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -52,6 +52,7 @@ export const enum ScriptOpcode {
     MAP_INDOORS,
     MAP_LIVE,
     MAP_LOCADDUNSAFE, // official
+    MAP_LOC,
     MAP_MEMBERS, // official
     MAP_MULTIWAY, // official
     MAP_PLAYERCOUNT, // official, see giant dwarf cutscene
@@ -444,7 +445,7 @@ export const enum ScriptOpcode {
     CONSOLE = 10000,
     ERROR,
     GETTIMESPENT, // custom: used to profile script execution (current duration)
-    TIMESPENT, // custom: used to profile script execution (record start time)
+    TIMESPENT // custom: used to profile script execution (record start time)
 }
 
 export const ScriptOpcodeMap: Map<string, number> = new Map([
@@ -499,6 +500,7 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['MAP_INDOORS', ScriptOpcode.MAP_INDOORS],
     ['MAP_LIVE', ScriptOpcode.MAP_LIVE],
     ['MAP_LOCADDUNSAFE', ScriptOpcode.MAP_LOCADDUNSAFE],
+    ['MAP_LOC', ScriptOpcode.MAP_LOC],
     ['MAP_MEMBERS', ScriptOpcode.MAP_MEMBERS],
     ['MAP_MULTIWAY', ScriptOpcode.MAP_MULTIWAY],
     ['MAP_PLAYERCOUNT', ScriptOpcode.MAP_PLAYERCOUNT],
@@ -863,9 +865,7 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['CONSOLE', ScriptOpcode.CONSOLE],
     ['ERROR', ScriptOpcode.ERROR],
     ['GETTIMESPENT', ScriptOpcode.GETTIMESPENT],
-    ['TIMESPENT', ScriptOpcode.TIMESPENT],
+    ['TIMESPENT', ScriptOpcode.TIMESPENT]
 ]);
 
-export const ScriptOpcodeNameMap: Map<number, string> = new Map(
-    Array.from(ScriptOpcodeMap.entries()).map(([key, value]) => [value, key])
-);
+export const ScriptOpcodeNameMap: Map<number, string> = new Map(Array.from(ScriptOpcodeMap.entries()).map(([key, value]) => [value, key]));

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -242,6 +242,34 @@ const ServerOps: CommandHandlers = {
         state.pushInt(0);
     },
 
+    [ScriptOpcode.MAP_LOC]: state => {
+        const coord: CoordGrid = check(state.popInt(), CoordValid);
+        for (let x = -8; x <= 8; x += 8) {
+            for (let z = -8; z <= 8; z += 8) {
+                for (const loc of World.gameMap.getZone(coord.x + x, coord.z + z, coord.level).getAllLocsSafe()) {
+                    const type = check(loc.type, LocTypeValid);
+
+                    if (type.active !== 1) {
+                        continue;
+                    }
+
+                    const width = loc.angle === LocAngle.NORTH || loc.angle === LocAngle.SOUTH ? loc.length : loc.width;
+                    const length = loc.angle === LocAngle.NORTH || loc.angle === LocAngle.SOUTH ? loc.width : loc.length;
+                    for (let index = 0; index < width * length; index++) {
+                        const deltaX = loc.x + (index % width);
+                        const deltaZ = loc.z + ((index / width) | 0);
+                        if (deltaX === coord.x && deltaZ === coord.z) {
+                            state.pushInt(1);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        state.pushInt(0);
+        state.pushInt(0);
+    },
+
     [ScriptOpcode.MAP_FINDSQUARE]: state => {
         const [coord, minRadius, maxRadius, type] = state.popInts(4);
         check(minRadius, NumberPositive);

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -212,40 +212,30 @@ const ServerOps: CommandHandlers = {
 
     [ScriptOpcode.MAP_LOCADDUNSAFE]: state => {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
+        // check all neighboring zones for big locs that bleed over...
+        // Maybe theres a smarter way to do this?
+        for (let x = -8; x <= 8; x += 8) {
+            for (let z = -8; z <= 8; z += 8) {
+                for (const loc of World.gameMap.getZone(coord.x + x, coord.z + z, coord.level).getAllLocsUnsafe()) {
+                    const type = check(loc.type, LocTypeValid);
 
-        for (const loc of World.gameMap.getZone(coord.x, coord.z, coord.level).getAllLocsUnsafe()) {
-            const type = check(loc.type, LocTypeValid);
-
-            if (type.active !== 1) {
-                continue;
-            }
-
-            const layer = loc.layer;
-
-            if (!loc.isActive && layer === LocLayer.WALL) {
-                continue;
-            }
-
-            if (layer === LocLayer.WALL) {
-                if (loc.x === coord.x && loc.z === coord.z) {
-                    state.pushInt(1);
-                    return;
-                }
-            } else if (layer === LocLayer.GROUND) {
-                const width = loc.angle === LocAngle.NORTH || loc.angle === LocAngle.SOUTH ? loc.length : loc.width;
-                const length = loc.angle === LocAngle.NORTH || loc.angle === LocAngle.SOUTH ? loc.width : loc.length;
-                for (let index = 0; index < width * length; index++) {
-                    const deltaX = loc.x + (index % width);
-                    const deltaZ = loc.z + ((index / width) | 0);
-                    if (deltaX === coord.x && deltaZ === coord.z) {
-                        state.pushInt(1);
-                        return;
+                    if (type.active !== 1) {
+                        continue;
                     }
-                }
-            } else if (layer === LocLayer.GROUND_DECOR || layer === LocLayer.WALL_DECOR) {
-                if (loc.x === coord.x && loc.z === coord.z) {
-                    state.pushInt(1);
-                    return;
+
+                    if (!loc.isActive && loc.layer === LocLayer.WALL) {
+                        continue;
+                    }
+                    const width = loc.angle === LocAngle.NORTH || loc.angle === LocAngle.SOUTH ? loc.length : loc.width;
+                    const length = loc.angle === LocAngle.NORTH || loc.angle === LocAngle.SOUTH ? loc.width : loc.length;
+                    for (let index = 0; index < width * length; index++) {
+                        const deltaX = loc.x + (index % width);
+                        const deltaZ = loc.z + ((index / width) | 0);
+                        if (deltaX === coord.x && deltaZ === coord.z) {
+                            state.pushInt(1);
+                            return;
+                        }
+                    }
                 }
             }
         }

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -212,10 +212,10 @@ const ServerOps: CommandHandlers = {
 
     [ScriptOpcode.MAP_LOCADDUNSAFE]: state => {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
-        // check all neighboring zones for big locs that bleed over...
+        // check south and west neighboring zones for big locs that bleed over...
         // Maybe theres a smarter way to do this?
-        for (let x = -8; x <= 8; x += 8) {
-            for (let z = -8; z <= 8; z += 8) {
+        for (let x = -8; x <= 0; x += 8) {
+            for (let z = -8; z <= 0; z += 8) {
                 for (const loc of World.gameMap.getZone(coord.x + x, coord.z + z, coord.level).getAllLocsUnsafe()) {
                     const type = check(loc.type, LocTypeValid);
 
@@ -244,8 +244,8 @@ const ServerOps: CommandHandlers = {
 
     [ScriptOpcode.MAP_LOC]: state => {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
-        for (let x = -8; x <= 8; x += 8) {
-            for (let z = -8; z <= 8; z += 8) {
+        for (let x = -8; x <= 0; x += 8) {
+            for (let z = -8; z <= 0; z += 8) {
                 for (const loc of World.gameMap.getZone(coord.x + x, coord.z + z, coord.level).getAllLocsSafe()) {
                     const type = check(loc.type, LocTypeValid);
 

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -267,7 +267,6 @@ const ServerOps: CommandHandlers = {
             }
         }
         state.pushInt(0);
-        state.pushInt(0);
     },
 
     [ScriptOpcode.MAP_FINDSQUARE]: state => {

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -242,7 +242,7 @@ const ServerOps: CommandHandlers = {
                         return;
                     }
                 }
-            } else if (layer === LocLayer.GROUND_DECOR) {
+            } else if (layer === LocLayer.GROUND_DECOR || layer === LocLayer.WALL_DECOR) {
                 if (loc.x === coord.x && loc.z === coord.z) {
                     state.pushInt(1);
                     return;


### PR DESCRIPTION
for 225+

In osrs, you can't firemake on top of wall decor locs. Here are some relevant tests:

https://github.com/user-attachments/assets/ef1c7cbf-3348-4a06-b079-766016650105

- When using a rope on the wall in castlewars, it spawns a wall decor loc. Dropping a flag checks for `map_locaddunsafe`, if the loc is unsafe it'll check a nearby tile instead.


https://github.com/user-attachments/assets/d35bc8f4-b1ee-4323-a1f0-c7f79a89f7cd



Before:

https://github.com/user-attachments/assets/0093d93f-371d-449f-a53a-d770a14005f2



After:


https://github.com/user-attachments/assets/ad0f2dc0-690e-48a3-82cc-efb6f0e66bd7

