### PR TITLE
feat: Support for bitwise hunt conditions

### DIFF
--- a/src/cache/config/HuntType.ts
+++ b/src/cache/config/HuntType.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 
-
 import { ConfigType } from '#/cache/config/ConfigType.js';
 import { HuntCheckNotTooStrong } from '#/engine/entity/hunt/HuntCheckNotTooStrong.js';
 import { HuntModeType } from '#/engine/entity/hunt/HuntModeType.js';
@@ -70,6 +69,8 @@ export default class HuntType extends ConfigType {
                 return value === checkValue;
             case '!':
                 return value !== checkValue;
+            case '&':
+                return (value & checkValue) === 0;
         }
         return false;
     }

--- a/tools/pack/config/HuntConfig.ts
+++ b/tools/pack/config/HuntConfig.ts
@@ -363,7 +363,7 @@ export function parseHuntConfig(key: string, value: string): ConfigValue | null 
         }
         const conditionWithVal = parts[1];
         const condition = conditionWithVal.charAt(0);
-        if (!['=', '>', '<', '!'].includes(condition)) {
+        if (!['=', '>', '<', '!', '&'].includes(condition)) {
             return null;
         }
         const varp = VarpPack.getByName(parts[0].slice(1));


### PR DESCRIPTION
Realistically could be for any revision, but wasn't needed until 274+. 

Shades hunt based on a bit of a varp. Eventually it becomes its own varbit but it isn't in 274.