### PR TITLE
fix: update variable name from varpInfo to varnInfo

### DIFF
--- a/tools/pack/Compiler.ts
+++ b/tools/pack/Compiler.ts
@@ -251,7 +251,7 @@ export function runServerCompiler() {
 
     VarNpcType.load('data/pack');
     for (let id = 0; id <= varnInfo.max; id++) {
-        if (typeof varpInfo.map[id] === 'undefined') {
+        if (typeof varnInfo.map[id] === 'undefined') {
             continue;
         }
 


### PR DESCRIPTION
This seems to using the wrong variable from a previous copy/paste. This updates to the correct variable.