### PR TITLE
feat: add date_minutes and date_runeday as callable engine functions

### DIFF
--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -426,6 +426,9 @@ export const enum ScriptOpcode {
     COS_DEG, // custom
     ATAN2_DEG, // custom
     ABS, // custom
+    DATE_MINUTES, // derived
+    DATE_RUNEDAY, // derived
+
 
     // Struct ops (4700-4799)
     STRUCT_PARAM = 4700,
@@ -851,6 +854,8 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['COS_DEG', ScriptOpcode.COS_DEG],
     ['ATAN2_DEG', ScriptOpcode.ATAN2_DEG],
     ['ABS', ScriptOpcode.ABS],
+    ['DATE_MINUTES', ScriptOpcode.DATE_MINUTES],
+    ['DATE_RUNEDAY', ScriptOpcode.DATE_RUNEDAY],
 
     ['STRUCT_PARAM', ScriptOpcode.STRUCT_PARAM],
 

--- a/src/engine/script/handlers/NumberOps.ts
+++ b/src/engine/script/handlers/NumberOps.ts
@@ -176,6 +176,16 @@ const NumberOps: CommandHandlers = {
 
     [ScriptOpcode.ABS]: state => {
         state.pushInt(Math.abs(state.popInt()));
+    },
+
+    [ScriptOpcode.DATE_MINUTES]: state => {
+        const currentMs = performance.timeOrigin + performance.now();
+        state.pushInt(Math.floor(currentMs / 60000));
+    },
+
+    [ScriptOpcode.DATE_RUNEDAY]: state => {
+        const currentMs = performance.timeOrigin + performance.now();
+        state.pushInt(Math.floor(currentMs / 86400000) - 11745);
     }
 };
 


### PR DESCRIPTION
Adds the following opcode:

ScriptOpcode.DATE_MINUTES
ScriptOpcode.DATE_RUNEDAY

date_minutes would return something like 29642690
date_runeday would return something like 8840 (this one takes away 11745 which looks like some random constant)

both should be the number of minutes and days from unix epoch.