### PR TITLE
fix: Improve auto sizing & add ability for hotkey to hide controls

### DIFF
--- a/view/client.ejs
+++ b/view/client.ejs
@@ -65,13 +65,14 @@
         }
 
         #controls {
-            margin-top: 3px;
-            margin-bottom: 10px;
+            margin-top: .5vh;
+            margin-bottom: .5vh;
+            height: 2vh;
         }
 
         #controls > a, #controls select, #controls optgroup, #controls optgroup > option {
             font-family: Arial, Helvetica, sans-serif;
-            font-size: 12px;
+            font-size: 1.5vh;
         }
 
         @keyframes blink {
@@ -147,6 +148,9 @@
             document.getElementById('controls').style.display = 'none';
             document.getElementById('hide-message').style.display = '';
 
+            let size = localStorage.getItem('canvasSize');
+            if (size === 'auto') { document.getElementById('canvas').style.height = '93vh'; }
+
             countDown = 0;
             hideMessage();
 
@@ -159,6 +163,8 @@
         function hideMessage() {
             if (countDown >= countDownMax) {
                 document.getElementById('hide-message').style.display = 'none';
+                let size = localStorage.getItem('canvasSize');
+                if (size) { setSize(size); }
                 return;
             }
 
@@ -174,6 +180,9 @@
             document.getElementById('controls').style.display = '';
             document.getElementById('hide-message').style.display = 'none';
 
+            let size = localStorage.getItem('canvasSize');
+            if (size) { setSize(size); }
+
             localStorage.removeItem('hideControls');
         }
 
@@ -181,7 +190,13 @@
             if ((e.ctrlKey || e.metaKey) && e.altKey) {
                 if (e.code === 'KeyI') {
                     e.preventDefault();
-                    showControls();
+                    let controls = localStorage.getItem('hideControls');
+                    if (controls) {
+                        showControls();
+                    }
+                    else {
+                        hideControls();
+                    }
                 }
             }
         });
@@ -229,8 +244,13 @@
                     canvas.style.maxWidth = 'none';
                     break;
                 case 'auto':
-                    canvas.style.width = '100%';
-                    canvas.style.height = 'auto';
+                    canvas.style.width = 'auto';
+                    if (document.getElementById('controls').style.display !== 'none'){
+                        canvas.style.height = '97vh';
+                    }
+                    else{
+                        canvas.style.height = '100vh';
+                    }
                     break;
             }
             document.getElementById('size').value = size;


### PR DESCRIPTION
I made improvements for the auto sizing option to be more dynamic and allow you to toggle it on using "ctrl + alt + i" as well. This fix is identical to the version I did for 254.

It now properly fits the vertical view height, taking up whatever real estate isn't taken up by the controls. When controls are hidden, the entire vertical view height is used.

Canvas: 97vh while controls are visible
<img width="2561" height="1520" alt="Screenshot_20260524_200610" src="https://github.com/user-attachments/assets/70efcb2e-b3f1-4f28-8048-f547312e6a3d" />

Canvas: 93vh while countdown is present
<img width="2561" height="1520" alt="Screenshot_20260524_200628" src="https://github.com/user-attachments/assets/ae688019-42f9-4d22-bf63-0f09cd2604b9" />

Canvas: 100vh when controls are hidden to fill the entire view
<img width="2561" height="1520" alt="Screenshot_20260524_200642" src="https://github.com/user-attachments/assets/c0df7660-9be5-4f90-a345-928239e75399" />

Note: this was tested locally without the top banner, values may need to be adjusted for the website version.