### PR TITLE
fix: I can't reach that! to occur less often

### DIFF
--- a/src/engine/entity/AllowRepath.ts
+++ b/src/engine/entity/AllowRepath.ts
@@ -1,4 +1,0 @@
-export const enum AllowRepath {
-    BEFOREDEST,
-    NONE
-}

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -7,7 +7,6 @@ import Entity from '#/engine/entity/Entity.js';
 import { EntityLifeCycle } from '#/engine/entity/EntityLifeCycle.js';
 import { Interaction } from '#/engine/entity/Interaction.js';
 import Loc from '#/engine/entity/Loc.js';
-import { AllowRepath } from './AllowRepath.js';
 import { MoveRestrict } from '#/engine/entity/MoveRestrict.js';
 import { MoveSpeed } from '#/engine/entity/MoveSpeed.js';
 import { MoveStrategy } from '#/engine/entity/MoveStrategy.js';
@@ -54,7 +53,6 @@ export default abstract class PathingEntity extends Entity {
     lastInt: number = -1; // resume_p_countdialog, ai_queue
     lastCrawl: boolean = false;
     lastMovement: number = 0;
-    allowRepath: AllowRepath = AllowRepath.BEFOREDEST;
 
     walktrigger: number = -1;
     walktriggerArg: number = 0; // used for npcs
@@ -255,7 +253,6 @@ export default abstract class PathingEntity extends Entity {
     queueWaypoint(x: number, z: number): void {
         this.waypoints[0] = CoordGrid.packCoord(0, x, z); // level doesn't matter here
         this.waypointIndex = 0;
-        this.setAllowRepath(AllowRepath.BEFOREDEST);
     }
 
     /**
@@ -269,11 +266,6 @@ export default abstract class PathingEntity extends Entity {
             index++;
         }
         this.waypointIndex = index;
-        this.setAllowRepath(AllowRepath.BEFOREDEST);
-    }
-
-    setAllowRepath(value: AllowRepath) {
-        this.allowRepath = value;
     }
 
     clearWaypoints(): void {
@@ -539,11 +531,6 @@ export default abstract class PathingEntity extends Entity {
             this.targetSubject.type = target.type;
         } else {
             this.targetSubject.type = -1;
-        }
-
-        if (interaction === Interaction.SCRIPT) {
-            // Allow repath
-            this.allowRepath = AllowRepath.BEFOREDEST;
         }
 
         this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), target instanceof NonPathingEntity && interaction === Interaction.ENGINE);

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -22,7 +22,6 @@ import { EntityTimer, PlayerTimerType } from '#/engine/entity/EntityTimer.js';
 import HeroPoints from '#/engine/entity/HeroPoints.js';
 import Loc from '#/engine/entity/Loc.js';
 import { ModalState } from '#/engine/entity/ModalState.js';
-import { AllowRepath } from './AllowRepath.js';
 import { MoveSpeed } from '#/engine/entity/MoveSpeed.js';
 import { MoveStrategy } from '#/engine/entity/MoveStrategy.js';
 import { isClientConnected } from '#/engine/entity/NetworkPlayer.js';
@@ -1075,7 +1074,7 @@ export default class Player extends PathingEntity {
                 return;
             }
 
-            if (this.isLastWaypoint() && this.allowRepath === AllowRepath.BEFOREDEST) {
+            if (this.isLastWaypoint()) {
                 this.naivePathToTarget();
             }
         } else if (this.isLastWaypoint()) {

--- a/src/network/game/client/handler/MoveClickHandler.ts
+++ b/src/network/game/client/handler/MoveClickHandler.ts
@@ -1,7 +1,6 @@
 import { CoordGrid } from '#/engine/CoordGrid.js';
 import { NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 import ClientGameMessageHandler from '#/network/game/client/ClientGameMessageHandler.js';
-import { AllowRepath } from '#/engine/entity/AllowRepath.js';
 import MoveClick from '#/network/game/client/model/MoveClick.js';
 import UnsetMapFlag from '#/network/game/server/model/UnsetMapFlag.js';
 import Environment from '#/util/Environment.js';
@@ -37,16 +36,12 @@ export default class MoveClickHandler extends ClientGameMessageHandler<MoveClick
         // Set new path
         if (Environment.node.clientRoutefinder) {
             player.userPath = [];
-            // this check ignores setting the path when the player is clicking on their current tile
-            if (message.path.length === 1 && start.x === player.x && start.z === player.z) {
-                player.queueWaypoints(player.userPath);
-                player.setAllowRepath(AllowRepath.NONE);
-            } else {
-                for (let i = 0; i < message.path.length; i++) {
-                    player.userPath[i] = CoordGrid.packCoord(player.level, message.path[i].x, message.path[i].z);
-                }
-                player.queueWaypoints(player.userPath);
+
+            for (let i = 0; i < message.path.length; i++) {
+                player.userPath[i] = CoordGrid.packCoord(player.level, message.path[i].x, message.path[i].z);
             }
+            player.queueWaypoints(player.userPath);
+
             player.processWalktrigger();
         } else {
             const dest = message.path[message.path.length - 1];


### PR DESCRIPTION
There was a bunch of unnecessary code that caused _I can't reach that!_ to occur more often than it should. It turns out, the proper cases of _I can't reach that!_ were already handled naturally by the existing pathing code.

Here's an example of when we should receive _I can't reach that!_, and this is matched in-game

https://youtu.be/Fq3lhq14QsE?si=_EHVIf5ehohvufet&t=47