### PR TITLE
fix: (289, all) mark obj_find as a conditional

### DIFF
--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -840,7 +840,8 @@ const ScriptOpcodePointers: {
     },
     [ScriptOpcode.OBJ_FIND]: {
         set: ['active_obj'],
-        set2: ['active_obj2']
+        set2: ['active_obj2'],
+        conditional: true
     },
     [ScriptOpcode.OBJ_FINDALLZONE]: {
         set: ['find_obj'],


### PR DESCRIPTION
This is only for compiler warnings but it now should match loc_find and npc_find