### PR TITLE
fix: (289, all) Match player and npc facing logic to OSRS

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -707,13 +707,15 @@ class World {
                 }
                 // - engine queue
                 player.processEngineQueue();
-                // Update target facing -- marks the FACE_ENTITY mask the same tick the op set the target
-                // (the op runs before this in processClientsIn), before processInteraction can clear it.
+                // Face the interaction target -- both halves, the same tick the op set the target (the op ran
+                // in processClientsIn) and before processInteraction can clear it: the FACE_ENTITY mask, plus
+                // the serverside faceAngle toward a pathing target (for new observers).
                 player.setFaceEntity();
+                player.reorientEntity();
                 // - interactions
                 // - movement
                 player.processInteraction();
-                // Reorient during the player's own turn (not processInfo).
+                // After movement: face a loc/obj target if we walked over and held still (needs stepsTaken).
                 player.reorient();
 
                 // - run energy
@@ -987,7 +989,7 @@ class World {
 
         // TODO: benchmark this?
         for (const player of this.playerLoop.all()) {
-            // reorient() runs in the player's turn (processPlayers), not here.
+            // facing (reorientEntity/reorient) runs in the player's turn (processPlayers), not here.
             player.buildArea.rebuildNormal(); // set origin before compute player is why this is above.
 
             const appearance = player.masks & PlayerInfoProt.APPEARANCE ? player.generateAppearance() : (player.appearanceBuf ?? player.generateAppearance());
@@ -1040,7 +1042,7 @@ class World {
         }
 
         for (const npc of this.npcs) {
-            // reorient() runs in Npc.turn(), not here.
+            // facing (reorientEntity/reorient) runs in Npc.turn(), not here.
             rsbuf.computeNpc(
                 npc.x,
                 npc.level,

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -707,13 +707,13 @@ class World {
                 }
                 // - engine queue
                 player.processEngineQueue();
-                // Update target facing
-                player.setFaceEntity();
                 // - interactions
                 // - movement
                 player.processInteraction();
-                // experimental: reorient during the player's own turn (moved out of processInfo).
+                // Reorient toward the target and update the face-entity mask together, after movement
+                // (mirrors Npc.turn()).
                 player.reorient();
+                player.setFaceEntity();
 
                 // - run energy
                 player.updateEnergy();
@@ -986,7 +986,7 @@ class World {
 
         // TODO: benchmark this?
         for (const player of this.playerLoop.all()) {
-            // experimental: reorient() moved into the player's turn (processPlayers).
+            // reorient() runs in the player's turn (processPlayers), not here.
             player.buildArea.rebuildNormal(); // set origin before compute player is why this is above.
 
             const appearance = player.masks & PlayerInfoProt.APPEARANCE ? player.generateAppearance() : (player.appearanceBuf ?? player.generateAppearance());
@@ -1039,7 +1039,7 @@ class World {
         }
 
         for (const npc of this.npcs) {
-            // experimental: reorient() moved into Npc.turn().
+            // reorient() runs in Npc.turn(), not here.
             rsbuf.computeNpc(
                 npc.x,
                 npc.level,

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -712,6 +712,8 @@ class World {
                 // - interactions
                 // - movement
                 player.processInteraction();
+                // experimental: reorient during the player's own turn (moved out of processInfo).
+                player.reorient();
 
                 // - run energy
                 player.updateEnergy();
@@ -984,7 +986,7 @@ class World {
 
         // TODO: benchmark this?
         for (const player of this.playerLoop.all()) {
-            player.reorient();
+            // experimental: reorient() moved into the player's turn (processPlayers).
             player.buildArea.rebuildNormal(); // set origin before compute player is why this is above.
 
             const appearance = player.masks & PlayerInfoProt.APPEARANCE ? player.generateAppearance() : (player.appearanceBuf ?? player.generateAppearance());
@@ -1037,7 +1039,7 @@ class World {
         }
 
         for (const npc of this.npcs) {
-            npc.reorient();
+            // experimental: reorient() moved into Npc.turn().
             rsbuf.computeNpc(
                 npc.x,
                 npc.level,

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -707,13 +707,14 @@ class World {
                 }
                 // - engine queue
                 player.processEngineQueue();
+                // Update target facing -- marks the FACE_ENTITY mask the same tick the op set the target
+                // (the op runs before this in processClientsIn), before processInteraction can clear it.
+                player.setFaceEntity();
                 // - interactions
                 // - movement
                 player.processInteraction();
-                // Reorient toward the target and update the face-entity mask together, after movement
-                // (mirrors Npc.turn()).
+                // Reorient during the player's own turn (not processInfo).
                 player.reorient();
-                player.setFaceEntity();
 
                 // - run energy
                 player.updateEnergy();

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -179,8 +179,8 @@ export default class Npc extends PathingEntity {
         this.processQueue();
         // Movement-Interactions
         this.processMovementInteraction();
-        // experimental: reorient toward the target during the npc's own turn (moved out of the post-movement
-        // processInfo sweep) so an npc that didn't take a turn this tick keeps its spawn orientation.
+        // Reorient toward the target during the npc's own turn (not the post-movement processInfo sweep),
+        // so an npc that didn't take a turn this tick keeps its spawn orientation. Paired with setFaceEntity below.
         this.reorient();
         // Update target facing
         this.setFaceEntity();

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -179,8 +179,11 @@ export default class Npc extends PathingEntity {
         this.processQueue();
         // Movement-Interactions
         this.processMovementInteraction();
-        // Reorient toward the target during the npc's own turn (not the post-movement processInfo sweep),
-        // so an npc that didn't take a turn this tick keeps its spawn orientation. Paired with setFaceEntity below.
+        // Reorient during the npc's own turn (not the post-movement processInfo sweep), so an npc that didn't
+        // take a turn this tick keeps its spawn orientation. An npc's target is set during its turn, so both
+        // run here after movement: reorientEntity() (faceAngle toward a player/npc) and reorient() (face a
+        // loc/obj once stopped), then the FACE_ENTITY mask.
+        this.reorientEntity();
         this.reorient();
         // Update target facing
         this.setFaceEntity();

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -179,6 +179,9 @@ export default class Npc extends PathingEntity {
         this.processQueue();
         // Movement-Interactions
         this.processMovementInteraction();
+        // experimental: reorient toward the target during the npc's own turn (moved out of the post-movement
+        // processInfo sweep) so an npc that didn't take a turn this tick keeps its spawn orientation.
+        this.reorient();
         // Update target facing
         this.setFaceEntity();
         // Dev note: Is this necessary?

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -366,10 +366,9 @@ export default abstract class PathingEntity extends Entity {
             // Try to focus back on a possible target because they move.
             this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), false);
         } else if (this.targetX !== -1 && this.stepsTaken === 0) {
-            // If the entity targeted then moved off, then we try to refocus after running out of steps.
-            // this is only set when clicking non pathing entities.
-            // we do not update the client, the client was already notified of the update.
-            this.focus(this.targetX, this.targetZ, false);
+            // Non-pathing target (loc/obj): face it once we've stopped. experimental: client=true here --
+            // setInteraction no longer ships the face-coord mask, so this turn-time reorient does.
+            this.focus(this.targetX, this.targetZ, true);
             this.targetX = -1;
             this.targetZ = -1;
         }
@@ -515,7 +514,7 @@ export default abstract class PathingEntity extends Entity {
         }
     }
 
-    setInteraction(interaction: Interaction, target: Entity, op: TargetOp, com?: number): boolean {
+    setInteraction(_interaction: Interaction, target: Entity, op: TargetOp, com?: number): boolean {
         if (!target.isValid(this instanceof Player ? this.hash64 : undefined)) {
             return false;
         }
@@ -533,8 +532,9 @@ export default abstract class PathingEntity extends Entity {
             this.targetSubject.type = -1;
         }
 
-        this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), target instanceof NonPathingEntity && interaction === Interaction.ENGINE);
-
+        // experimental: setting an interaction no longer focus()es here -- facing only changes during the
+        // entity's own turn (in reorient(), called from Npc.turn / processPlayers). For non-pathing targets
+        // we still record targetX/Z for that turn-time reorient to consume.
         if (target instanceof NonPathingEntity) {
             this.targetX = CoordGrid.fine(target.x, target.width);
             this.targetZ = CoordGrid.fine(target.z, target.length);

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -355,19 +355,30 @@ export default abstract class PathingEntity extends Entity {
     }
 
     /**
-     * Try to focus back on a possible target.
-     * This is needed because the target can move.
-     * This should be done after all pathing entities have moved.
-     * If the entity targeted then moved off, then we try to refocus after running out of steps.
+     * Serverside orientation toward a pathing (player/npc) target. Refreshed every turn BEFORE movement,
+     * paired with setFaceEntity() -- the two halves of "face the entity I'm interacting with." client=false:
+     * not pushed to existing watchers (FACE_ENTITY tracks the target for them), it only feeds the orientation
+     * a NEW observer gets in the add packet. No movement dependency, so it runs before processInteraction and
+     * captures the target before processInteraction can clear it.
      */
-    reorient(): void {
+    reorientEntity(): void {
         const target: Entity | null = this.target;
         if (target instanceof PathingEntity) {
-            // Try to focus back on a possible target because they move.
             this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), false);
-        } else if (this.targetX !== -1 && this.stepsTaken === 0) {
-            // Non-pathing target (loc/obj): face it once we've stopped. client=true here -- setInteraction
-            // no longer ships the face-coord mask, so this turn-time reorient does.
+        }
+    }
+
+    /**
+     * Reorient toward a non-pathing (loc/obj) target once we've stopped moving -- the entity targeted it,
+     * walked over, and ran out of steps (stepsTaken === 0). MUST run AFTER movement so stepsTaken reflects
+     * this tick. client=true: this is the only path that ships the face-coord for loc/obj facing. A pathing
+     * target is handled by reorientEntity() before the move, so it's skipped here.
+     */
+    reorient(): void {
+        if (this.target instanceof PathingEntity) {
+            return;
+        }
+        if (this.targetX !== -1 && this.stepsTaken === 0) {
             this.focus(this.targetX, this.targetZ, true);
             this.targetX = -1;
             this.targetZ = -1;
@@ -533,8 +544,8 @@ export default abstract class PathingEntity extends Entity {
         }
 
         // Setting an interaction no longer focus()es here -- facing only changes during the entity's own
-        // turn (in reorient(), called from Npc.turn / processPlayers). For non-pathing targets we still
-        // record targetX/Z for that turn-time reorient to consume.
+        // turn (reorientEntity() for a pathing target, reorient() for loc/obj; both from Npc.turn /
+        // processPlayers). For non-pathing targets we still record targetX/Z for reorient() to consume.
         if (target instanceof NonPathingEntity) {
             this.targetX = CoordGrid.fine(target.x, target.width);
             this.targetZ = CoordGrid.fine(target.z, target.length);

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -366,8 +366,8 @@ export default abstract class PathingEntity extends Entity {
             // Try to focus back on a possible target because they move.
             this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), false);
         } else if (this.targetX !== -1 && this.stepsTaken === 0) {
-            // Non-pathing target (loc/obj): face it once we've stopped. experimental: client=true here --
-            // setInteraction no longer ships the face-coord mask, so this turn-time reorient does.
+            // Non-pathing target (loc/obj): face it once we've stopped. client=true here -- setInteraction
+            // no longer ships the face-coord mask, so this turn-time reorient does.
             this.focus(this.targetX, this.targetZ, true);
             this.targetX = -1;
             this.targetZ = -1;
@@ -532,9 +532,9 @@ export default abstract class PathingEntity extends Entity {
             this.targetSubject.type = -1;
         }
 
-        // experimental: setting an interaction no longer focus()es here -- facing only changes during the
-        // entity's own turn (in reorient(), called from Npc.turn / processPlayers). For non-pathing targets
-        // we still record targetX/Z for that turn-time reorient to consume.
+        // Setting an interaction no longer focus()es here -- facing only changes during the entity's own
+        // turn (in reorient(), called from Npc.turn / processPlayers). For non-pathing targets we still
+        // record targetX/Z for that turn-time reorient to consume.
         if (target instanceof NonPathingEntity) {
             this.targetX = CoordGrid.fine(target.x, target.width);
             this.targetZ = CoordGrid.fine(target.z, target.length);


### PR DESCRIPTION
Our tile-facing logic was all over the place prior. It's now cleaned up such that tile-facing towards a target is only set during an entity's turn. This matches osrs