### PR TITLE
fix: guard IPv6 login bucket parse so one login can't crash the world

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -916,7 +916,8 @@ class World {
                 } else if (remote.indexOf(':') !== -1) {
                     // IPv6 - site prefix determines the bucket
                     const hextets = remote.split(':');
-                    const bucket = parseInt(hextets[2], 16) % 256;
+                    const prefix = parseInt(hextets[2], 16);
+                    const bucket = Number.isNaN(prefix) ? 0 : prefix % 256;
                     this.playerLoop.add(BigInt(bucket), player);
                 }
             } else {


### PR DESCRIPTION
A single IPv6 login crashes the whole world.

`World.processLogins()` buckets players by address; the IPv6 branch does `parseInt(hextets[2], 16) % 256`. With `::` zero-compression that group is usually empty (`2001:db8::1` → `['2001','db8','','1']`), so `parseInt` is `NaN` and `BigInt(NaN)` throws. The login loop is unguarded, so it unwinds to the `cycle()` catch, which removes every player and `process.exit(1)`s. That path also never notifies the friends server, so those players stay "already logged in" until their sessions expire.

Fix: fall back to bucket 0 for an empty/non-hex group. Valid addresses are unchanged (`2001:4860:4860::8888` → 96, `fe80::1` → 1).
