### PR TITLE
fix: HashTable.all() skips entries keyed 0n

### DIFF
--- a/src/datastruct/HashTable.ts
+++ b/src/datastruct/HashTable.ts
@@ -42,17 +42,13 @@ export default class HashTable<T extends Linkable> {
         value.key = key;
     }
 
-    findnext(node: Linkable): T | null {
-        return node.next?.key !== 0n ? node.next as T : null;
-    }
-
     *all(): IterableIterator<T> {
         for (let bucket = 0; bucket < this.bucketCount; bucket++) {
-            let node = this.findnext(this.buckets[bucket]);
+            const sentinel: T = this.buckets[bucket];
 
-            while (node !== null) {
-                // need to store the next node early in case it's removed while iterating
-                const next = this.findnext(node);
+            for (let node: T = sentinel.next as T; node !== sentinel; ) {
+                // store the next node early in case it's removed while iterating
+                const next: T = node.next as T;
                 yield node;
                 node = next;
             }


### PR DESCRIPTION
`Linkable.key` defaults to `0n`, but `all()`/`findnext` used `key === 0n` as the bucket-sentinel marker. So a real entry keyed `0n` — and anything inserted behind it in the same bucket — was skipped by `all()`, even though `find()` (which terminates on sentinel identity) still returned it.

```ts
const t = new HashTable(8);
t.add(0n, a); t.add(8n, b);   // both hash to bucket 0
[...t.all()]                  // [] — misses both
t.find(0n) === a              // true
```

Fix: iterate `all()` by sentinel identity like `find()` already does, and drop the now-unused `findnext`. `0n` becomes a valid key.
